### PR TITLE
fix (docker daemon config):

### DIFF
--- a/etc/docker/daemon.json
+++ b/etc/docker/daemon.json
@@ -1,5 +1,9 @@
 {
   "storage-driver": "btrfs",
+  "default-address-pools":[
+    { "base":"172.80.0.0/16", "size":24 },
+    { "base":"172.90.0.0/16", "size":24 }
+  ],
   "bip": "11.11.0.1/16",
   "features": {
     "buildkit": true


### PR DESCRIPTION
Updates the reference config because the older one was missing "default-address-pools" which are critical in running docker-compose on OpenStack at CCM.