### PR TITLE
Updates to Vagrant, deploy OpenStack instance from Vagrant

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ services:
 
 To deploy CanDIGv2, follow one of the available install guides in `docs/`:
 
+* [Vagrant Deployment Guide (with instructions for OpenStack)](./docs/install-vagrant.md)
 * [Docker Deployment Guide](./docs/install-docker.md)
 * [Kubernetes Deployment Guide](./docs/install-kubernetes.md)
 * [Tox Deployment Guide](./docs/install-tox.md)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -22,27 +22,5 @@ Vagrant.configure('2') do |config|
   end
 
   # run custom shell on provision
-  config.vm.provision 'shell', privileged: false, inline: <<-SHELL
-    sudo apt-get update
-    sudo apt-get upgrade -y
-    sudo apt-get dist-upgrade -y
-
-    sudo apt-get install -y build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libreadline-dev libffi-dev wget curl git
-    sudo apt-get install -y libsqlite3-dev libbz2-dev liblzma-dev lzma sqlite3
-    sudo apt-get install -y apt-transport-https ca-certificates gnupg2 software-properties-common
-
-    curl -fsSL https://download.docker.com/linux/debian/gpg | sudo apt-key add -
-    sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable"
-
-    sudo apt-get update
-    sudo apt-get install -y docker-ce docker-ce-cli containerd.io
-
-    sudo systemctl enable docker
-    sudo systemctl start docker
-    sudo usermod -aG docker $(whoami)
-
-    sudo chown -R $(whoami):$(whoami) /home/vagrant/candig
-    sudo apt-get autoclean
-    sudo apt-get autoremove -y
-  SHELL
+  config.vm.provision 'shell', privileged: false, path: "provision.sh", args: ["/home/vagrant/candig"]
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,11 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+# Install vagrant-disksize to allow resizing the vagrant box disk.
+unless Vagrant.has_plugin?("vagrant-disksize")
+    raise  Vagrant::Errors::VagrantError.new, "vagrant-disksize plugin is missing. Please install it using 'vagrant plugin install vagrant-disksize' and rerun 'vagrant up'"
+end
+
 Vagrant.configure('2') do |config|
   config.vm.box = 'debian/contrib-buster64'
   config.vm.hostname = 'candig.local'
@@ -8,6 +13,7 @@ Vagrant.configure('2') do |config|
   # config.vm.network "forwarded_port", guest: 443, host: 443
   config.vm.synced_folder '.', '/home/vagrant/candig', type: 'virtualbox'
 
+  config.disksize.size = '50GB'
   config.vm.provider 'virtualbox' do |vb|
     vb.name = 'candig-dev'
     vb.gui = false

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -51,6 +51,6 @@ Vagrant.configure('2') do |config|
     os.server_name        = 'candig-vagrant'
     override.vm.provision 'shell', privileged: false, path: "provision.sh", args: ["."]
     override.vm.provision :reload
-    override.vm.provision 'shell', privileged: false, path: "setup_containers.sh", args: ["~/CanDIGv2"]
+    override.vm.provision 'shell', privileged: false, path: "setup_containers.sh", args: ["/home/ubuntu/CanDIGv2"]
   end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,6 +6,11 @@ unless Vagrant.has_plugin?("vagrant-disksize")
     raise  Vagrant::Errors::VagrantError.new, "vagrant-disksize plugin is missing. Please install it using 'vagrant plugin install vagrant-disksize' and rerun 'vagrant up'"
 end
 
+# Install vagrant-reload to allow reloading during provisioning.
+unless Vagrant.has_plugin?("vagrant-reload")
+    raise  Vagrant::Errors::VagrantError.new, "vagrant-reload plugin is missing. Please install it using 'vagrant plugin install vagrant-reload' and rerun 'vagrant up'"
+end
+
 Vagrant.configure('2') do |config|
   config.vm.hostname = 'candig-dev'
 
@@ -22,6 +27,8 @@ Vagrant.configure('2') do |config|
     vb.customize ['modifyvm', :id, '--memory', '4096']
     # run custom shell on provision
     override.vm.provision 'shell', privileged: false, path: "provision.sh", args: ["/home/vagrant/candig"]
+    override.vm.provision :reload
+    override.vm.provision 'shell', privileged: false, path: "setup_containers.sh", args: ["/home/vagrant/candig"]
   end
 
   config.vm.provider :openstack do |os, override|
@@ -42,9 +49,8 @@ Vagrant.configure('2') do |config|
     os.flavor             = 'm1.large'
     os.image              = 'UbuntuServer-1804-2019Nov20'
     os.server_name        = 'candig-vagrant'
-    override.vm.provision 'shell', privileged: false, path: "provision.sh"
-    override.vm.provision 'shell', privileged: false, path: "setup_containers.sh"
+    override.vm.provision 'shell', privileged: false, path: "provision.sh", args: ["."]
+    override.vm.provision :reload
+    override.vm.provision 'shell', privileged: false, path: "setup_containers.sh", args: ["~/CanDIGv2"]
   end
-
-
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,19 +7,39 @@ unless Vagrant.has_plugin?("vagrant-disksize")
 end
 
 Vagrant.configure('2') do |config|
-  config.vm.box = 'debian/contrib-buster64'
-  config.vm.hostname = 'candig.local'
-  # config.vm.network "forwarded_port", guest: 80, host: 80
-  # config.vm.network "forwarded_port", guest: 443, host: 443
-  config.vm.synced_folder '.', '/home/vagrant/candig', type: 'virtualbox'
-
-  config.disksize.size = '50GB'
   config.vm.provider 'virtualbox' do |vb|
+    config.vm.hostname = 'candig.local'
+    config.disksize.size = '50GB'
+    config.vm.box = 'debian/contrib-buster64'
+#     config.vm.network "forwarded_port", guest: 80, host: 80
+#     config.vm.network "forwarded_port", guest: 443, host: 443
+    config.vm.synced_folder '.', '/home/vagrant/candig', type: 'virtualbox'
     vb.name = 'candig-dev'
     vb.gui = false
     vb.customize ['modifyvm', :id, '--cpus', 4]
     vb.customize ['modifyvm', :id, '--memory', '4096']
   end
+
+  config.vm.provider :openstack do |os|
+    config.ssh.username = 'ubuntu'
+    config.ssh.private_key_path = '/Users/daisie/.ssh/id_rsa'
+    os.username = ENV["OS_USERNAME"]
+    os.password = ENV["OS_PASSWORD"]
+    os.user_domain_name = ENV["OS_USER_DOMAIN_NAME"]
+    os.project_name = ENV["OS_PROJECT_NAME"]
+    os.project_domain_name = ENV["OS_PROJECT_DOMAIN_ID"]
+    os.identity_api_version = ENV["OS_IDENTITY_API_VERSION"]
+    os.region = ENV["OS_REGION_NAME"]
+    os.openstack_auth_url = ENV["OS_AUTH_URL"]
+    os.interface_type = ENV["OS_INTERFACE"]
+
+    os.keypair_name       = 'daisieh'
+    os.flavor             = 'm1.large'
+    os.image              = 'UbuntuServer-1804-2019Nov20'
+    os.floating_ip_pool   = 'OS DMZ External 205.189.58.128/27'
+    os.server_name        = 'daisieh'
+  end
+
 
   # run custom shell on provision
   config.vm.provision 'shell', privileged: false, path: "provision.sh", args: ["/home/vagrant/candig"]

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,22 +7,25 @@ unless Vagrant.has_plugin?("vagrant-disksize")
 end
 
 Vagrant.configure('2') do |config|
-  config.vm.provider 'virtualbox' do |vb|
-    config.vm.hostname = 'candig.local'
-    config.disksize.size = '50GB'
-    config.vm.box = 'debian/contrib-buster64'
+  config.vm.box = 'generic/ubuntu1804'
+  config.vm.hostname = 'candig-dev'
+  config.vm.synced_folder '.', '/home/vagrant/candig', type: 'virtualbox'
+
+  config.vm.provider 'virtualbox' do |vb, override|
+    override.vm.box = 'debian/contrib-buster64'
+    override.vm.hostname = 'candig.local'
+    override.disksize.size = '50GB'
 #     config.vm.network "forwarded_port", guest: 80, host: 80
 #     config.vm.network "forwarded_port", guest: 443, host: 443
-    config.vm.synced_folder '.', '/home/vagrant/candig', type: 'virtualbox'
     vb.name = 'candig-dev'
     vb.gui = false
     vb.customize ['modifyvm', :id, '--cpus', 4]
     vb.customize ['modifyvm', :id, '--memory', '4096']
   end
 
-  config.vm.provider :openstack do |os|
-    config.ssh.username = 'ubuntu'
-    config.ssh.private_key_path = '/Users/daisie/.ssh/id_rsa'
+  config.vm.provider :openstack do |os, override|
+    override.ssh.username = 'ubuntu'
+    override.ssh.private_key_path = ENV["OS_PRIVATEKEY_PATH"]
     os.username = ENV["OS_USERNAME"]
     os.password = ENV["OS_PASSWORD"]
     os.user_domain_name = ENV["OS_USER_DOMAIN_NAME"]
@@ -32,12 +35,11 @@ Vagrant.configure('2') do |config|
     os.region = ENV["OS_REGION_NAME"]
     os.openstack_auth_url = ENV["OS_AUTH_URL"]
     os.interface_type = ENV["OS_INTERFACE"]
-
     os.keypair_name       = ENV["OS_KEYPAIR"]
+    
     os.flavor             = 'm1.large'
     os.image              = 'UbuntuServer-1804-2019Nov20'
-    os.floating_ip_pool   = 'OS DMZ External 205.189.58.128/27'
-    os.server_name        = 'vagrant-dev'
+    os.server_name        = 'candig-vagrant'
   end
 
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -33,11 +33,11 @@ Vagrant.configure('2') do |config|
     os.openstack_auth_url = ENV["OS_AUTH_URL"]
     os.interface_type = ENV["OS_INTERFACE"]
 
-    os.keypair_name       = 'daisieh'
+    os.keypair_name       = ENV["OS_KEYPAIR"]
     os.flavor             = 'm1.large'
     os.image              = 'UbuntuServer-1804-2019Nov20'
     os.floating_ip_pool   = 'OS DMZ External 205.189.58.128/27'
-    os.server_name        = 'daisieh'
+    os.server_name        = 'vagrant-dev'
   end
 
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -43,6 +43,7 @@ Vagrant.configure('2') do |config|
     os.image              = 'UbuntuServer-1804-2019Nov20'
     os.server_name        = 'candig-vagrant'
     override.vm.provision 'shell', privileged: false, path: "provision.sh"
+    override.vm.provision 'shell', privileged: false, path: "setup_containers.sh"
   end
 
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,20 +7,21 @@ unless Vagrant.has_plugin?("vagrant-disksize")
 end
 
 Vagrant.configure('2') do |config|
-  config.vm.box = 'generic/ubuntu1804'
   config.vm.hostname = 'candig-dev'
-  config.vm.synced_folder '.', '/home/vagrant/candig', type: 'virtualbox'
 
   config.vm.provider 'virtualbox' do |vb, override|
+    override.vm.synced_folder '.', '/home/vagrant/candig', type: 'virtualbox'
     override.vm.box = 'debian/contrib-buster64'
     override.vm.hostname = 'candig.local'
     override.disksize.size = '50GB'
-#     config.vm.network "forwarded_port", guest: 80, host: 80
-#     config.vm.network "forwarded_port", guest: 443, host: 443
+#     override.vm.network "forwarded_port", guest: 80, host: 80
+#     override.vm.network "forwarded_port", guest: 443, host: 443
     vb.name = 'candig-dev'
     vb.gui = false
     vb.customize ['modifyvm', :id, '--cpus', 4]
     vb.customize ['modifyvm', :id, '--memory', '4096']
+    # run custom shell on provision
+    override.vm.provision 'shell', privileged: false, path: "provision.sh", args: ["/home/vagrant/candig"]
   end
 
   config.vm.provider :openstack do |os, override|
@@ -40,9 +41,8 @@ Vagrant.configure('2') do |config|
     os.flavor             = 'm1.large'
     os.image              = 'UbuntuServer-1804-2019Nov20'
     os.server_name        = 'candig-vagrant'
+    override.vm.provision 'shell', privileged: false, path: "provision.sh"
   end
 
 
-  # run custom shell on provision
-  config.vm.provision 'shell', privileged: false, path: "provision.sh", args: ["/home/vagrant/candig"]
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -25,6 +25,7 @@ Vagrant.configure('2') do |config|
   end
 
   config.vm.provider :openstack do |os, override|
+    override.vm.synced_folder '.', '/home/vagrant/candig', type: 'virtualbox', disabled: true
     override.ssh.username = 'ubuntu'
     override.ssh.private_key_path = ENV["OS_PRIVATEKEY_PATH"]
     os.username = ENV["OS_USERNAME"]

--- a/docs/install-vagrant.md
+++ b/docs/install-vagrant.md
@@ -1,0 +1,39 @@
+# CanDIGv2 Install Guide
+
+- - -
+
+[Vagrant](https://www.vagrantup.com) can be used to automate the process of setting up a [Docker deployment](install-docker.md) of CanDIGv2 on a virtual machine on your local machine or to create an instance on an [OpenStack deployment](https://www.openstack.org).
+
+## Set up Vagrant
+
+You'll need to have compatible versions of [Vagrant](https://www.vagrantup.com) and [VirtualBox](https://www.virtualbox.org) on the system you'll be using to deploy the Vagrant VM. We tested using Vagrant 2.0.3 and VirtualBox 5.2: other versions may not play nicely together or load the plugins correctly.
+
+If you're using a Debian or Ubuntu system, you can try running [setup_vagrant.sh](setup_vagrant.sh) to install the recommended versions. Otherwise, install the following:
+
+* [Vagrant 2.0.3](https://releases.hashicorp.com/vagrant/2.0.3/) ([installation instructions](https://www.vagrantup.com/docs/installation))
+* [VirtualBox 5.2.34](https://download.virtualbox.org/virtualbox/5.2.34/) ([installation instructions](https://www.virtualbox.org/manual/ch02.html))
+
+Then install plugins:
+```
+vagrant plugin install vagrant-disksize
+vagrant plugin install vagrant-openstack-provider
+vagrant plugin install vagrant-reload
+```
+## Run Vagrant
+
+By default, `vagrant up` will use the VirtualBox provider to create a VM on your local machine. 
+
+You can also use Vagrant to deploy an instance on OpenStack:
+* Get your credentials from your OpenStack dashboard: go to Project > API Access on the sidebar, then click the "Download OpenStack RC File" button and download the OpenStack RC File (Identity API v3).
+* Either run the downloaded shell script to load the required environment variables, or export them into your shell directly.
+* Export two additional environment variables:
+  * `OS_KEYPAIR` should correspond to a valid keypair in OpenStack Dashboard > Project > Compute > Key Pairs. Choose one that does not have a passphrase associated with it.
+  * `OS_PRIVATEKEY_PATH` should be the path of the private key associated with that keypair.
+* Run `vagrant up --provider=openstack`.
+
+After it's up, you can access your VM with `vagrant ssh`. If you want to suspend the VM, `vagrant suspend` or `vagrant halt` ([what's the difference?](https://stackoverflow.com/questions/42549087/in-vagrant-which-is-better-out-of-halt-and-suspend#42551494)). 
+
+## Cleanup
+
+To destroy your VM entirely, run `vagrant destroy`.
+

--- a/etc/venv/activate.sh
+++ b/etc/venv/activate.sh
@@ -1,6 +1,4 @@
 source $PWD/bin/miniconda3/etc/profile.d/conda.sh
 conda activate candig
-pip install -U -r $PWD/etc/venv/requirements.txt
-#pip install -U -r $PWD/etc/venv/requirements-dev.txt
 export PATH="$PWD/bin:$PATH"
 #eval $(docker-machine env manager)

--- a/provision.sh
+++ b/provision.sh
@@ -2,11 +2,11 @@
 # Optional args: CanDIGv2 repo path, CanDIGv2 repo branch
 
 sudo apt-get update
+sudo apt-get upgrade -y
 
 # remove grub file and recreate, in case of version conflicts
 sudo rm /boot/grub/menu.lst
 sudo update-grub-legacy-ec2 -y
-sudo apt-get upgrade -y
 sudo apt-get dist-upgrade -y
 
 sudo apt-get install -y build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libreadline-dev libffi-dev wget curl git make gcc

--- a/provision.sh
+++ b/provision.sh
@@ -2,7 +2,7 @@
 # Optional args: CanDIGv2 repo path, CanDIGv2 repo branch
 
 sudo apt-get update
-# sudo apt-get upgrade -y
+sudo apt-get upgrade -y
 
 sudo rm /boot/grub/menu.lst
 sudo update-grub-legacy-ec2 -y

--- a/provision.sh
+++ b/provision.sh
@@ -2,10 +2,11 @@
 # Optional args: CanDIGv2 repo path, CanDIGv2 repo branch
 
 sudo apt-get update
-sudo apt-get upgrade -y
 
+# remove grub file and recreate, in case of version conflicts
 sudo rm /boot/grub/menu.lst
 sudo update-grub-legacy-ec2 -y
+sudo apt-get upgrade -y
 sudo apt-get dist-upgrade -y
 
 sudo apt-get install -y build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libreadline-dev libffi-dev wget curl git make gcc

--- a/provision.sh
+++ b/provision.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Optional args: CanDIGv2 repo path, CanDIGv2 repo branch
+
+sudo apt-get update
+sudo apt-get upgrade -y
+sudo apt-get dist-upgrade -y
+
+sudo apt-get install -y build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libreadline-dev libffi-dev wget curl git make gcc
+sudo apt-get install -y libsqlite3-dev libbz2-dev liblzma-dev lzma sqlite3
+sudo apt-get install -y apt-transport-https ca-certificates gnupg2 software-properties-common
+
+if [ -n $1 ]
+then
+    echo $1
+    path=$1
+else
+    path=$PWD
+fi
+
+if [ -n $2 ]
+then
+    echo $2
+    branch="-b $2"
+else
+    branch=""
+fi
+
+cd $path
+if grep -qs "CanDIGv2" .git/config; then
+    echo "Specified path is a CanDIGv2 repo"
+    git checkout $2
+else
+    echo "Cloning CanDIGv2..."
+    git clone $branch https://github.com/CanDIG/CanDIGv2.git
+    cd CanDIGv2/
+fi
+
+sudo chown -R $(whoami):$(whoami) $path
+git submodule update --init --recursive
+cp -i etc/env/example.env .env
+
+dist=$(lsb_release -is)
+codename=$(lsb_release -cs)
+
+curl -fsSL https://download.docker.com/linux/${dist,,}/gpg | sudo apt-key add -
+sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/${dist,,} $(lsb_release -cs) stable"
+
+sudo apt-get update
+sudo apt-get install -y docker-ce docker-ce-cli containerd.io
+sudo apt-get autoclean
+sudo apt-get autoremove -y
+sudo systemctl enable docker
+sudo systemctl start docker
+sudo usermod -aG docker $(whoami)
+
+make bin-all
+make init-conda
+
+source $PWD/bin/miniconda3/etc/profile.d/conda.sh
+conda activate candig
+pip install -U -r $PWD/etc/venv/requirements.txt

--- a/provision.sh
+++ b/provision.sh
@@ -63,3 +63,4 @@ make init-conda
 source $PWD/bin/miniconda3/etc/profile.d/conda.sh
 conda activate candig
 pip install -U -r $PWD/etc/venv/requirements.txt
+#pip install -U -r $PWD/etc/venv/requirements-dev.txt

--- a/provision.sh
+++ b/provision.sh
@@ -2,7 +2,10 @@
 # Optional args: CanDIGv2 repo path, CanDIGv2 repo branch
 
 sudo apt-get update
-sudo apt-get upgrade -y
+# sudo apt-get upgrade -y
+
+sudo rm /boot/grub/menu.lst
+sudo update-grub-legacy-ec2 -y
 sudo apt-get dist-upgrade -y
 
 sudo apt-get install -y build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libreadline-dev libffi-dev wget curl git make gcc

--- a/setup_containers.sh
+++ b/setup_containers.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+cd $1
 source $PWD/bin/miniconda3/etc/profile.d/conda.sh
 conda activate candig
 export PATH="$PWD/bin:$PATH"

--- a/setup_containers.sh
+++ b/setup_containers.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+source $PWD/bin/miniconda3/etc/profile.d/conda.sh
+conda activate candig
+export PATH="$PWD/bin:$PATH"
+eval $(docker-machine env manager)
+make init-docker
+make images

--- a/setup_containers.sh
+++ b/setup_containers.sh
@@ -7,3 +7,4 @@ export PATH="$PWD/bin:$PATH"
 eval $(docker-machine env manager)
 make init-docker
 make images
+make compose

--- a/setup_vagrant.sh
+++ b/setup_vagrant.sh
@@ -1,10 +1,21 @@
 #!/usr/bin/env bash
 
-# works for a Debian-based box
+# works for a Debian-based box: 
 
 sudo apt-get update
-sudo apt-get install -y virtualbox unzip bsdtar
+sudo apt-get install -y unzip bsdtar
+
+# Ubuntu 18.04 by default installs virtualbox-5.2
+sudo apt-get install -y virtualbox
+# if that doesn't work, try the following:
+# sudo add-apt-repository "deb [arch=amd64] https://download.virtualbox.org/virtualbox/debian buster contrib"
+# wget -q https://www.virtualbox.org/download/oracle_vbox_2016.asc -O- | sudo apt-key add -
+# sudo apt-get update
+# sudo apt-get install virtualbox-5.2
+
 wget -c https://releases.hashicorp.com/vagrant/2.0.3/vagrant_2.0.3_x86_64.deb
 sudo dpkg -i vagrant_2.0.3_x86_64.deb
+rm vagrant_2.0.3_x86_64.deb
 vagrant plugin install vagrant-disksize
 vagrant plugin install vagrant-openstack-provider
+vagrant plugin install vagrant-reload

--- a/setup_vagrant.sh
+++ b/setup_vagrant.sh
@@ -7,3 +7,4 @@ sudo apt-get install -y virtualbox unzip bsdtar
 wget -c https://releases.hashicorp.com/vagrant/2.0.3/vagrant_2.0.3_x86_64.deb
 sudo dpkg -i vagrant_2.0.3_x86_64.deb
 vagrant plugin install vagrant-disksize
+vagrant plugin install vagrant-openstack-provider

--- a/setup_vagrant.sh
+++ b/setup_vagrant.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# works for a Debian-based box
+
+sudo apt-get update
+sudo apt-get install -y virtualbox unzip bsdtar
+wget -c https://releases.hashicorp.com/vagrant/2.0.3/vagrant_2.0.3_x86_64.deb
+sudo dpkg -i vagrant_2.0.3_x86_64.deb
+vagrant plugin install vagrant-disksize


### PR DESCRIPTION
All of the provisioning that was in the last version of the Vagrantfile is now broken out into separate shell scripts. provision.sh is the main provisioner, but you have to log out and log back in again to pick up the Docker group bits, so now it runs the vagrant-reload plugin and then runs setup_containers.sh, which finishes the setup.

Most of the information should be in the documentation that I've written as well. The only undocumented quirk: if you want to use the Vagrantfile but pull from a branch of CanDIGv2 that is not the main develop branch, add a second argument to line 29 or line 52 of the Vagrantfile as needed:
```
    override.vm.provision 'shell', privileged: false, path: "provision.sh", args: ["/home/vagrant/candig", "develop-shell-2"]
```