### PR TITLE
Pin version of alpine to 3.13

### DIFF
--- a/etc/env/example.env
+++ b/etc/env/example.env
@@ -36,6 +36,8 @@ DOCKER_REGISTRY=candig
 # options are [json, fluentd]
 DOCKER_LOG_DRIVER=json
 
+ALPINE_VERSION=3.13
+
 # docker swarm
 # options are [manager, worker]
 SWARM_MODE=manager

--- a/lib/chord-metadata/Dockerfile
+++ b/lib/chord-metadata/Dockerfile
@@ -1,5 +1,5 @@
 ARG venv_python
-
+ARG alpine_version
 FROM python:${venv_python}-alpine${alpine_version}
 
 LABEL Maintainer="CanDIG Project"

--- a/lib/chord-metadata/Dockerfile
+++ b/lib/chord-metadata/Dockerfile
@@ -1,6 +1,6 @@
 ARG venv_python
 
-FROM python:${venv_python}-alpine
+FROM python:${venv_python}-alpine${alpine_version}
 
 LABEL Maintainer="CanDIG Project"
 

--- a/lib/chord-metadata/docker-compose.yml
+++ b/lib/chord-metadata/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       context: $PWD/lib/chord-metadata
       args:
         venv_python: "${VENV_PYTHON}"
+        alpine_version: "${ALPINE_VERSION}"
     image: ${DOCKER_REGISTRY}/chord-metadata:${CHORD_METADATA_VERSION:-latest}
     networks:
       - ${DOCKER_NET}

--- a/lib/drs-server/Dockerfile
+++ b/lib/drs-server/Dockerfile
@@ -1,6 +1,6 @@
 ARG venv_python
 
-FROM python:${venv_python}-alpine
+FROM python:${venv_python}-alpine${alpine_version}
 
 LABEL Maintainer="CanDIG Project"
 

--- a/lib/drs-server/Dockerfile
+++ b/lib/drs-server/Dockerfile
@@ -1,5 +1,3 @@
-
-
 ARG venv_python
 ARG alpine_version
 FROM python:${venv_python}-alpine${alpine_version}

--- a/lib/drs-server/Dockerfile
+++ b/lib/drs-server/Dockerfile
@@ -4,7 +4,7 @@ ARG venv_python
 
 FROM python:${venv_python}-alpine${alpine_version}
 
-RUN echo ${alpine_version}
+RUN echo $venv_python
 
 LABEL Maintainer="CanDIG Project"
 

--- a/lib/drs-server/Dockerfile
+++ b/lib/drs-server/Dockerfile
@@ -1,10 +1,8 @@
 
 
 ARG venv_python
-
+ARG alpine_version
 FROM python:${venv_python}-alpine${alpine_version}
-
-RUN echo $venv_python
 
 LABEL Maintainer="CanDIG Project"
 

--- a/lib/drs-server/Dockerfile
+++ b/lib/drs-server/Dockerfile
@@ -1,8 +1,10 @@
+
+
 ARG venv_python
-ARG alpine_version
-RUN echo ${alpine_version}
 
 FROM python:${venv_python}-alpine${alpine_version}
+
+RUN echo ${alpine_version}
 
 LABEL Maintainer="CanDIG Project"
 

--- a/lib/drs-server/Dockerfile
+++ b/lib/drs-server/Dockerfile
@@ -1,4 +1,6 @@
 ARG venv_python
+ARG alpine_version
+RUN echo ${alpine_version}
 
 FROM python:${venv_python}-alpine${alpine_version}
 

--- a/lib/drs-server/docker-compose.yml
+++ b/lib/drs-server/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       context: $PWD/lib/drs-server
       args:
         venv_python: "${VENV_PYTHON}"
+        alpine_version: "${ALPINE_VERSION}"
     image: ${DOCKER_REGISTRY}/chord-drs:${CHORD_DRS_VERSION:-latest}
     networks:
       - ${DOCKER_NET}

--- a/lib/federation-service/Dockerfile
+++ b/lib/federation-service/Dockerfile
@@ -1,5 +1,5 @@
 ARG venv_python
-
+ARG alpine_version
 FROM python:${venv_python}-alpine${alpine_version}
 
 LABEL Maintainer="CanDIG Project"

--- a/lib/federation-service/Dockerfile
+++ b/lib/federation-service/Dockerfile
@@ -1,6 +1,6 @@
 ARG venv_python
 
-FROM python:${venv_python}-alpine
+FROM python:${venv_python}-alpine${alpine_version}
 
 LABEL Maintainer="CanDIG Project"
 

--- a/lib/federation-service/docker-compose.yml
+++ b/lib/federation-service/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       context: $PWD/lib/federation-service
       args:
         venv_python: "${VENV_PYTHON}"
+        alpine_version: "${ALPINE_VERSION}"
     image: ${DOCKER_REGISTRY}/federation-service:${FEDERATION_VERSION:-latest}
     networks:
       - ${DOCKER_NET}

--- a/lib/htsget-server/docker-compose.yml
+++ b/lib/htsget-server/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       context: $PWD/lib/htsget-server/htsget_app
       args:
         venv_python: "${VENV_PYTHON}"
+        alpine_version: "${ALPINE_VERSION}"
     image: ${DOCKER_REGISTRY}/htsget-app:${HTSGET_APP_VERSION:-latest}
     networks:
       - ${DOCKER_NET}

--- a/lib/templates/Dockerfile
+++ b/lib/templates/Dockerfile
@@ -1,5 +1,5 @@
 ARG venv_python
-
+ARG alpine_version
 FROM python:${venv_python}-alpine${alpine_version}
 
 LABEL Maintainer="CanDIG Project"

--- a/lib/templates/Dockerfile
+++ b/lib/templates/Dockerfile
@@ -1,6 +1,6 @@
 ARG venv_python
 
-FROM python:${venv_python}-alpine
+FROM python:${venv_python}-alpine${alpine_version}
 
 LABEL Maintainer="CanDIG Project"
 

--- a/lib/templates/docker-compose.yml
+++ b/lib/templates/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       #context: $PWD/lib/{{service_name}}/{{submodule_name}}
       args:
         venv_python: "${VENV_PYTHON}"
+        alpine_version: "${ALPINE_VERSION}"
     image: ${DOCKER_REGISTRY}/{{service_name}}:${{{service_version}}:-latest}
     #volumes:
       #- {{service_name}}-data:/data


### PR DESCRIPTION
This pins alpine to 3.13 for chord-metadata, federation-service, and chord-drs. htsget-server has its Dockerfile in its submodule, so we'll need to merge that and then update the tag here.