### PR TITLE
Add CanDIG Data Portal to the stack

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,3 +25,6 @@
 [submodule "lib/cancogen-dashboard/cancogen_dashboard"]
   path = lib/cancogen-dashboard/cancogen_dashboard
   url = https://github.com/CanDIG/cancogen_dashboard.git
+[submodule "lib/candig-data-portal/candig-data-portal"]
+  path = lib/candig-data-portal/candig-data-portal
+  url = https://github.com/CanDIG/candig-data-portal.git

--- a/README.md
+++ b/README.md
@@ -153,7 +153,14 @@ View additional Makefile options with `make help`.
 
 ## Services and Components
 
-The follwing table lists the details from the Data Flow Diagram in the "Overview" section.
+### Add new service
+
+New services can be added under `lib` directory.  Please refer to the
+[template for new services README](./lib/templates/README.md) for more details.
+
+### List of services
+
+The following table lists the details from the Data Flow Diagram in the "Overview" section.
 
 | Service/Component Name | Source | Notes                        |
 |------------------------|--------|------------------------------|
@@ -168,3 +175,4 @@ The follwing table lists the details from the Data Flow Diagram in the "Overview
 | CHORD DRS              | links  | DFD: `chord_drs`             |
 | IGV JS                 | links  | DFD: `igv_js`                |
 | WES Server             | links  | DFD: `wes_server`            |
+| CanDIG Data Portal     | links  | DFD:                         |

--- a/etc/env/example.env
+++ b/etc/env/example.env
@@ -301,3 +301,8 @@ CANCOGEN_METADATA_URL=http://chord-metadata:8008
 CANCOGEN_HTSGET_URL=http://htsget-app:3333
 CANCOGEN_DRS_URL=http://chord-drs:6000
 CANCOGEN_FEDERATION_URL=http://federation-service:4232/federation/search
+
+
+# candig-data-server (previously mcode)
+CANDIG_DATA_PORTAL_VERSION=v0.1.0
+CANDIG_DATA_PORTAL_PORT=2543

--- a/etc/env/example.env
+++ b/etc/env/example.env
@@ -2,7 +2,7 @@
 # - - -
 
 # site options
-CANDIG_MODULES=weavescope portainer consul traefik logging monitoring minio drs-server htsget-server chord-metadata datasets cnv-service rnaget candig-server federation-service cancogen-dashboard #wes-server jupyter igv authentication authorization
+CANDIG_MODULES=candig-data-portal weavescope portainer consul traefik logging monitoring minio drs-server htsget-server chord-metadata datasets cnv-service rnaget candig-server federation-service cancogen-dashboard #wes-server jupyter igv authentication authorization
 CANDIG_AUTH_MODULES=keycloak tyk opa vault
 
 # options are [<ip_addr>, <url>, host.docker.internal, docker.localhost]

--- a/lib/candig-data-portal/Dockerfile
+++ b/lib/candig-data-portal/Dockerfile
@@ -3,6 +3,7 @@ FROM node:14.16.0-alpine
 LABEL Maintainer="CanDIG Project"
 
 RUN apk add --no-cache git
+RUN apk add --no-cache curl
 
 COPY candig-data-portal /app/candig-data-portal
 

--- a/lib/candig-data-portal/Dockerfile
+++ b/lib/candig-data-portal/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:14.16.0-alpine
+
+LABEL Maintainer="CanDIG Project"
+
+RUN apk add --no-cache git
+
+COPY candig-data-portal /app/candig-data-portal
+
+WORKDIR /app/candig-data-portal
+
+RUN npm install
+
+ENTRYPOINT ["npm", "start"]

--- a/lib/candig-data-portal/docker-compose.yml
+++ b/lib/candig-data-portal/docker-compose.yml
@@ -1,0 +1,29 @@
+version: '3.7'
+
+services:
+  candig-data-portal:
+    build:
+      context: $PWD/lib/candig-data-portal
+      args:
+        alpine_version: "${ALPINE_VERSION}"
+    image: ${DOCKER_REGISTRY}/candig-data-portal:${CANDIG_DATA_PORTAL_VERSION:-latest}
+    networks:
+      - ${DOCKER_NET}
+    ports:
+      - "${CANDIG_DATA_PORTAL_PORT}:3000"
+    deploy:
+      placement:
+        constraints:
+          - node.role == worker
+      restart_policy:
+        condition: on-failure
+        delay: 5s
+        max_attempts: 3
+        window: 120s
+      labels:
+        - "traefik.enable=true"
+        - "traefik.docker.lbswarm=true"
+        - "traefik.http.routers.candig-data-portal.rule=Host(`candig-data-portal.${CANDIG_DOMAIN}`)"
+        - "traefik.http.services.candig-data-portal.loadbalancer.server.port=${CANDIG_DATA_PORTAL_PORT}"
+    logging: *default-logging
+    command: ["npm", "start"]

--- a/lib/candig-data-portal/docker-compose.yml
+++ b/lib/candig-data-portal/docker-compose.yml
@@ -26,4 +26,8 @@ services:
         - "traefik.http.routers.candig-data-portal.rule=Host(`candig-data-portal.${CANDIG_DOMAIN}`)"
         - "traefik.http.services.candig-data-portal.loadbalancer.server.port=${CANDIG_DATA_PORTAL_PORT}"
     logging: *default-logging
-    command: ["npm", "start"]
+    healthcheck:
+      test: [ "CMD", "curl", "http://localhost:3000" ]
+      interval: 30s
+      timeout: 20s
+      retries: 3


### PR DESCRIPTION
This is a requirement for DIG-650 because we need this dashboard.  This is a precursor for adding Tyk API for candig-data-portal.

- adds the submodule
- adds Dockerfile and docker-compose
- updates README

cc/ @haoyuanli 