### PR TITLE
HTSGET uses Opa to authorize user access to datasets

### DIFF
--- a/lib/htsget-server/docker-compose.yml
+++ b/lib/htsget-server/docker-compose.yml
@@ -9,6 +9,7 @@ services:
         alpine_version: "${ALPINE_VERSION}"
         opa_secret: "${CANDIG_OPA_SECRET}"
         opa_url: "${OPA_URL}"
+        candig_auth: "${CANDIG_AUTHORIZATION}"
     image: ${DOCKER_REGISTRY}/htsget-app:${HTSGET_APP_VERSION:-latest}
     networks:
       - ${DOCKER_NET}

--- a/lib/htsget-server/docker-compose.yml
+++ b/lib/htsget-server/docker-compose.yml
@@ -7,6 +7,8 @@ services:
       args:
         venv_python: "${VENV_PYTHON}"
         alpine_version: "${ALPINE_VERSION}"
+        opa_secret: "${CANDIG_OPA_SECRET}"
+        opa_url: "${OPA_URL}"
     image: ${DOCKER_REGISTRY}/htsget-app:${HTSGET_APP_VERSION:-latest}
     networks:
       - ${DOCKER_NET}

--- a/lib/opa/docker-compose.yml
+++ b/lib/opa/docker-compose.yml
@@ -53,6 +53,7 @@ services:
       - "app/permissions_engine/permissions.rego"
       - "app/permissions_engine/idp.rego"
       - "app/data.json"
+      - "app/permissions_engine/access.json"
     networks:
       - bridge-net
     deploy:


### PR DESCRIPTION
Set up the stack as described in docs/install-docker.md.

To test:
* Get a user token, where the values for the data parameters are found in the files in tmp/secrets:
```
curl -X "POST" "http://auth.docker.localhost:8080/auth/realms/candig/protocol/openid-connect/token" \
     -H 'Content-Type: application/x-www-form-urlencoded; charset=utf-8' \
     --data-urlencode "client_id=local_candig" \
     --data-urlencode "client_secret=<value in keycloak-client-local_candig-secret>" \
     --data-urlencode "grant_type=password" \
     --data-urlencode "username=<value in keycloak-test-user>" \
     --data-urlencode "password=<keycloak-test-user-password>" \
     --data-urlencode "scope=openid"
```
* Using the access_token, get the results from:
```
curl "http://docker.localhost:3333/htsget/v1/variants/NA20787" \
     -H 'Authorization: Bearer <access_token>'
```

You should get a result that looks like:
```
{
  "htsget": {
    "format": "VCF",
    "urls": [
      {
        "url": "http://docker.localhost:3333/htsget/v1/variants/data/NA20787?referenceName=None&start=9411602&end=19411602"
      },
      {
        "url": "http://docker.localhost:3333/htsget/v1/variants/data/NA20787?referenceName=None&start=19411602&end=29411602"
      },
      {
        "url": "http://docker.localhost:3333/htsget/v1/variants/data/NA20787?referenceName=None&start=29411602&end=39411602"
      },
      {
        "url": "http://docker.localhost:3333/htsget/v1/variants/data/NA20787?referenceName=None&start=39411602&end=48119634"
      }
    ]
  }
}
```

If you try to access NA18537 instead, you should get a 403: Forbidden error. If you don't pass an Authorization header at all, you'll get a 401: Unauthorized error.