### PR TITLE
The candig data portal doesn't connect to the right endpoint by default

### DIFF
--- a/lib/candig-data-portal/Dockerfile
+++ b/lib/candig-data-portal/Dockerfile
@@ -1,13 +1,13 @@
+FROM node:14.16.0-alpine as build
+
 ARG candig_data_portal_url
 ARG katsu_api_target_url
-
-FROM node:14.16.0-alpine as build
 
 LABEL Maintainer="CanDIG Project"
 
 
-ENV CANDIG_DATA_PORTAL_URL=$candig_data_portal_url
-ENV TYK_KATSU_API_TARGET=$katsu_api_target_url
+ENV REACT_APP_CANDIG_SERVER=$candig_data_portal_url
+ENV REACT_APP_KATSU_API_SERVER=$katsu_api_target_url
 
 
 RUN apk update


### PR DESCRIPTION
The `ARG`s specified before `FROM` are only usable in the `FROM` line, so they should be defined after the `FROM` line.

The `ENV` variables were not the the ones that the data portal is using.