### PR TITLE
mount minio-data in candig-server

### DIFF
--- a/lib/candig-server/docker-compose.yml
+++ b/lib/candig-server/docker-compose.yml
@@ -9,6 +9,8 @@ services:
         #candig_version: ${CANDIG_SERVER_VERSION}
         #candig_ingest: ${CANDIG_INGEST_VERSION}
     image: ${DOCKER_REGISTRY}/candig-server:${CANDIG_SERVER_VERSION}
+    volumes:
+      - minio-data:/data
     networks:
       - ${DOCKER_NET}
     ports:


### PR DESCRIPTION
For the circumstance in which we control the entire stack and we're uploading genomic files to our minio, it is convenient to not have to re-upload them to candig-server. (useful for federation tests)