### PR TITLE
Add switches to Makefile to download M1 binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ endif
 bin-traefik: mkdir
 	echo "    started bin-traefik" >> $(LOGFILE)
 ifeq ($(VENV_OS), arm64mac)
-	curl -Lo $(DIR)/bin/miniconda_install.sh \
+	curl -Lo $(DIR)/bin/traefik.tar.gz \
 		https://github.com/traefik/traefik/releases/download/v$(TRAEFIK_VERSION)/traefik_v$(TRAEFIK_VERSION)_darwin_arm64.tar.gz
 else
 	curl -Lo $(DIR)/bin/traefik.tar.gz \
@@ -658,7 +658,7 @@ ssl-cert:
 		-subj '/C=CA/ST=ON/L=Toronto/O=CanDIG/CN=CanDIG Self-Signed Cert'
 
 	cp $(DIR)/etc/ssl/site.cnf $(DIR)/tmp/ssl/site.cnf
-	sed -i s/CANDIG_DOMAIN/$(CANDIG_DOMAIN)/ $(DIR)/tmp/ssl/site.cnf
+	sed -i.bak s/CANDIG_DOMAIN/$(CANDIG_DOMAIN)/ $(DIR)/tmp/ssl/site.cnf
 	openssl x509 -req -days 750 -in $(DIR)/tmp/ssl/selfsigned-site.csr -sha256 \
 		-CA $(DIR)/tmp/ssl/selfsigned-root-ca.crt \
 		-CAkey $(DIR)/tmp/ssl/selfsigned-root-ca.key \
@@ -666,7 +666,7 @@ ssl-cert:
 		-extfile $(DIR)/tmp/ssl/site.cnf -extensions server
 
 	cp $(DIR)/etc/ssl/alt_names.txt $(DIR)/tmp/ssl/alt_names.txt
-	sed -i s/CANDIG_DOMAIN/$(CANDIG_DOMAIN)/ $(DIR)/tmp/ssl/alt_names.txt
+	sed -i.bak s/CANDIG_DOMAIN/$(CANDIG_DOMAIN)/ $(DIR)/tmp/ssl/alt_names.txt
 	openssl x509 -req -days 365 -in $(DIR)/tmp/ssl/selfsigned-root-ca.csr \
 	    -sha256 \
 	    -signkey $(DIR)/tmp/ssl/selfsigned-root-ca.key \

--- a/Makefile
+++ b/Makefile
@@ -92,18 +92,18 @@ bin-docker-machine: mkdir
 #<<<
 bin-minio: mkdir
 	echo "    started bin-minio" >> $(LOGFILE)
-	ifeq ($(VENV_OS), arm64mac)
-		curl -Lo $(DIR)/bin/minio \
-			https://dl.minio.io/server/minio/release/darwin-arm64/minio
-		curl -Lo $(DIR)/bin/mc \
-			https://dl.minio.io/client/mc/release/darwin-arm64/mc
-	endif
-	ifneq ($(VENV_OS), arm64mac)
-		curl -Lo $(DIR)/bin/minio \
-			https://dl.minio.io/server/minio/release/$(VENV_OS)-amd64/minio
-		curl -Lo $(DIR)/bin/mc \
-			https://dl.minio.io/client/mc/release/$(VENV_OS)-amd64/mc
-	endif
+ifeq ($(VENV_OS), arm64mac)
+	curl -Lo $(DIR)/bin/minio \
+		https://dl.minio.io/server/minio/release/darwin-arm64/minio
+	curl -Lo $(DIR)/bin/mc \
+		https://dl.minio.io/client/mc/release/darwin-arm64/mc
+endif
+ifneq ($(VENV_OS), arm64mac)
+	curl -Lo $(DIR)/bin/minio \
+		https://dl.minio.io/server/minio/release/$(VENV_OS)-amd64/minio
+	curl -Lo $(DIR)/bin/mc \
+		https://dl.minio.io/client/mc/release/$(VENV_OS)-amd64/mc
+endif
 	chmod 755 $(DIR)/bin/minio
 	chmod 755 $(DIR)/bin/mc
 	echo "    finished bin-minio" >> $(LOGFILE)
@@ -117,14 +117,14 @@ bin-minio: mkdir
 bin-prometheus: mkdir
 	echo "    started bin-prometheus" >> $(LOGFILE)
 	mkdir -p $(DIR)/bin/prometheus
-	ifeq ($(VENV_OS), arm64mac)
-		curl -Lo $(DIR)/bin/prometheus/prometheus.tar.gz \
-			https://github.com/prometheus/prometheus/releases/download/v$(PROMETHEUS_VERSION)/prometheus-$(PROMETHEUS_VERSION).darwin-arm64.tar.gz
-	endif
-	ifneq ($(VENV_OS), arm64mac)
-		curl -Lo $(DIR)/bin/prometheus/prometheus.tar.gz \
-			https://github.com/prometheus/prometheus/releases/download/v$(PROMETHEUS_VERSION)/prometheus-$(PROMETHEUS_VERSION).$(VENV_OS)-amd64.tar.gz
-	endif
+ifeq ($(VENV_OS), arm64mac)
+	curl -Lo $(DIR)/bin/prometheus/prometheus.tar.gz \
+		https://github.com/prometheus/prometheus/releases/download/v$(PROMETHEUS_VERSION)/prometheus-$(PROMETHEUS_VERSION).darwin-arm64.tar.gz
+endif
+ifneq ($(VENV_OS), arm64mac)
+	curl -Lo $(DIR)/bin/prometheus/prometheus.tar.gz \
+		https://github.com/prometheus/prometheus/releases/download/v$(PROMETHEUS_VERSION)/prometheus-$(PROMETHEUS_VERSION).$(VENV_OS)-amd64.tar.gz
+endif
 	tar --strip-components=1 -zxvf $(DIR)/bin/prometheus/prometheus.tar.gz -C $(DIR)/bin/prometheus
 	chmod 755 $(DIR)/bin/prometheus/prometheus
 	echo "    finished bin-prometheus" >> $(LOGFILE)
@@ -137,14 +137,14 @@ bin-prometheus: mkdir
 #<<<
 bin-traefik: mkdir
 	echo "    started bin-traefik" >> $(LOGFILE)
-	ifeq ($(VENV_OS), arm64mac)
-		curl -Lo $(DIR)/bin/miniconda_install.sh \
-			https://github.com/traefik/traefik/releases/download/v$(TRAEFIK_VERSION)/traefik_v$(TRAEFIK_VERSION)_darwin_arm64.tar.gz
-	endif
-	ifneq ($(VENV_OS, arm64mac)
-		curl -Lo $(DIR)/bin/traefik.tar.gz \
-			https://github.com/traefik/traefik/releases/download/v$(TRAEFIK_VERSION)/traefik_v$(TRAEFIK_VERSION)_$(VENV_OS)_amd64.tar.gz
-	endif
+ifeq ($(VENV_OS), arm64mac)
+	curl -Lo $(DIR)/bin/miniconda_install.sh \
+		https://github.com/traefik/traefik/releases/download/v$(TRAEFIK_VERSION)/traefik_v$(TRAEFIK_VERSION)_darwin_arm64.tar.gz
+endif
+ifneq ($(VENV_OS, arm64mac)
+	curl -Lo $(DIR)/bin/traefik.tar.gz \
+		https://github.com/traefik/traefik/releases/download/v$(TRAEFIK_VERSION)/traefik_v$(TRAEFIK_VERSION)_$(VENV_OS)_amd64.tar.gz
+endif
 	tar -xvzf $(DIR)/bin/traefik.tar.gz -C bin/
 	chmod 755 $(DIR)/bin/traefik
 	echo "    finished bin-traefik" >> $(LOGFILE)

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,10 @@ ifeq ($(VENV_OS), darwin)
 	curl -Lo $(DIR)/bin/miniconda_install.sh \
 		https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
 endif
+ifeq ($(VENV_OS), arm64mac)
+	curl -Lo $(DIR)/bin/miniconda_install.sh \
+		https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-arm64.sh
+endif
 	bash $(DIR)/bin/miniconda_install.sh -f -b -u -p $(DIR)/bin/miniconda3
 	# init is needed to create bash aliases for conda but it won't work
 	# until you source the script that ships with conda
@@ -128,10 +132,18 @@ bin-minikube: mkdir
 #<<<
 bin-minio: mkdir
 	echo "    started bin-minio" >> $(LOGFILE)
-	curl -Lo $(DIR)/bin/minio \
-		https://dl.minio.io/server/minio/release/$(VENV_OS)-amd64/minio
-	curl -Lo $(DIR)/bin/mc \
-		https://dl.minio.io/client/mc/release/$(VENV_OS)-amd64/mc
+	ifeq ($(VENV_OS), arm64mac)
+		curl -Lo $(DIR)/bin/minio \
+			https://dl.minio.io/server/minio/release/darwin-arm64/minio
+		curl -Lo $(DIR)/bin/mc \
+			https://dl.minio.io/client/mc/release/darwin-arm64/mc
+	endif
+	ifneq ($(VENV_OS), arm64mac)
+		curl -Lo $(DIR)/bin/minio \
+			https://dl.minio.io/server/minio/release/$(VENV_OS)-amd64/minio
+		curl -Lo $(DIR)/bin/mc \
+			https://dl.minio.io/client/mc/release/$(VENV_OS)-amd64/mc
+	endif
 	chmod 755 $(DIR)/bin/minio
 	chmod 755 $(DIR)/bin/mc
 	echo "    finished bin-minio" >> $(LOGFILE)
@@ -145,8 +157,14 @@ bin-minio: mkdir
 bin-prometheus: mkdir
 	echo "    started bin-prometheus" >> $(LOGFILE)
 	mkdir -p $(DIR)/bin/prometheus
-	curl -Lo $(DIR)/bin/prometheus/prometheus.tar.gz \
-		https://github.com/prometheus/prometheus/releases/download/v$(PROMETHEUS_VERSION)/prometheus-$(PROMETHEUS_VERSION).$(VENV_OS)-amd64.tar.gz
+	ifeq ($(VENV_OS), arm64mac)
+		curl -Lo $(DIR)/bin/prometheus/prometheus.tar.gz \
+			https://github.com/prometheus/prometheus/releases/download/v$(PROMETHEUS_VERSION)/prometheus-$(PROMETHEUS_VERSION).darwin-arm64.tar.gz
+	endif
+	ifneq ($(VENV_OS), arm64mac)
+		curl -Lo $(DIR)/bin/prometheus/prometheus.tar.gz \
+			https://github.com/prometheus/prometheus/releases/download/v$(PROMETHEUS_VERSION)/prometheus-$(PROMETHEUS_VERSION).$(VENV_OS)-amd64.tar.gz
+	endif
 	tar --strip-components=1 -zxvf $(DIR)/bin/prometheus/prometheus.tar.gz -C $(DIR)/bin/prometheus
 	chmod 755 $(DIR)/bin/prometheus/prometheus
 	echo "    finished bin-prometheus" >> $(LOGFILE)
@@ -159,8 +177,14 @@ bin-prometheus: mkdir
 #<<<
 bin-traefik: mkdir
 	echo "    started bin-traefik" >> $(LOGFILE)
-	curl -Lo $(DIR)/bin/traefik.tar.gz \
-		https://github.com/traefik/traefik/releases/download/v$(TRAEFIK_VERSION)/traefik_v$(TRAEFIK_VERSION)_$(VENV_OS)_amd64.tar.gz
+	ifeq ($(VENV_OS), arm64mac)
+		curl -Lo $(DIR)/bin/miniconda_install.sh \
+			https://github.com/traefik/traefik/releases/download/v$(TRAEFIK_VERSION)/traefik_v$(TRAEFIK_VERSION)_darwin_arm64.tar.gz
+	endif
+	ifneq ($(VENV_OS, arm64mac)
+		curl -Lo $(DIR)/bin/traefik.tar.gz \
+			https://github.com/traefik/traefik/releases/download/v$(TRAEFIK_VERSION)/traefik_v$(TRAEFIK_VERSION)_$(VENV_OS)_amd64.tar.gz
+	endif
 	tar -xvzf $(DIR)/bin/traefik.tar.gz -C bin/
 	chmod 755 $(DIR)/bin/traefik
 	echo "    finished bin-traefik" >> $(LOGFILE)

--- a/Makefile
+++ b/Makefile
@@ -97,8 +97,7 @@ ifeq ($(VENV_OS), arm64mac)
 		https://dl.minio.io/server/minio/release/darwin-arm64/minio
 	curl -Lo $(DIR)/bin/mc \
 		https://dl.minio.io/client/mc/release/darwin-arm64/mc
-endif
-ifneq ($(VENV_OS), arm64mac)
+else
 	curl -Lo $(DIR)/bin/minio \
 		https://dl.minio.io/server/minio/release/$(VENV_OS)-amd64/minio
 	curl -Lo $(DIR)/bin/mc \
@@ -120,8 +119,7 @@ bin-prometheus: mkdir
 ifeq ($(VENV_OS), arm64mac)
 	curl -Lo $(DIR)/bin/prometheus/prometheus.tar.gz \
 		https://github.com/prometheus/prometheus/releases/download/v$(PROMETHEUS_VERSION)/prometheus-$(PROMETHEUS_VERSION).darwin-arm64.tar.gz
-endif
-ifneq ($(VENV_OS), arm64mac)
+else
 	curl -Lo $(DIR)/bin/prometheus/prometheus.tar.gz \
 		https://github.com/prometheus/prometheus/releases/download/v$(PROMETHEUS_VERSION)/prometheus-$(PROMETHEUS_VERSION).$(VENV_OS)-amd64.tar.gz
 endif
@@ -140,8 +138,7 @@ bin-traefik: mkdir
 ifeq ($(VENV_OS), arm64mac)
 	curl -Lo $(DIR)/bin/miniconda_install.sh \
 		https://github.com/traefik/traefik/releases/download/v$(TRAEFIK_VERSION)/traefik_v$(TRAEFIK_VERSION)_darwin_arm64.tar.gz
-endif
-ifneq ($(VENV_OS, arm64mac)
+else
 	curl -Lo $(DIR)/bin/traefik.tar.gz \
 		https://github.com/traefik/traefik/releases/download/v$(TRAEFIK_VERSION)/traefik_v$(TRAEFIK_VERSION)_$(VENV_OS)_amd64.tar.gz
 endif

--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ endif
 bin-traefik: mkdir
 	echo "    started bin-traefik" >> $(LOGFILE)
 ifeq ($(VENV_OS), arm64mac)
-	curl -Lo $(DIR)/bin/miniconda_install.sh \
+	curl -Lo $(DIR)/bin/traefik.tar.gz \
 		https://github.com/traefik/traefik/releases/download/v$(TRAEFIK_VERSION)/traefik_v$(TRAEFIK_VERSION)_darwin_arm64.tar.gz
 else
 	curl -Lo $(DIR)/bin/traefik.tar.gz \

--- a/Makefile
+++ b/Makefile
@@ -43,8 +43,7 @@ mkdir:
 
 #<<<
 .PHONY: bin-all
-bin-all: bin-conda bin-docker-machine bin-kompose bin-kubectl \
-	bin-minikube bin-minio bin-traefik bin-prometheus
+bin-all: bin-conda bin-docker-machine bin-minio bin-traefik bin-prometheus
 
 
 #>>>
@@ -84,45 +83,6 @@ bin-docker-machine: mkdir
 		https://github.com/docker/machine/releases/download/v0.16.2/docker-machine-`uname -s`-`uname -m`
 	chmod 755 $(DIR)/bin/docker-machine
 	echo "    finished bin-docker-machine" >> $(LOGFILE)
-
-
-#>>>
-# download kompose (for kubernetes deployment)
-# make bin-kompose
-
-#<<<
-bin-kompose: mkdir
-	echo "    started bin-kompose" >> $(LOGFILE)
-	curl -Lo $(DIR)/bin/kompose \
-		https://github.com/kubernetes/kompose/releases/download/v1.21.0/kompose-$(VENV_OS)-amd64
-	chmod 755 $(DIR)/bin/kompose
-	echo "    finished bin-kompose" >> $(LOGFILE)
-
-
-#>>>
-# download latest kubectl (for kubernetes deployment)
-# make bin-kubectl
-
-#<<<
-bin-kubectl: mkdir
-	echo "    started bin-kubectl" >> $(LOGFILE)
-	curl -Lo $(DIR)/bin/kubectl \
-		https://storage.googleapis.com/kubernetes-release/release/v1.18.6/bin/$(VENV_OS)/amd64/kubectl
-	chmod 755 $(DIR)/bin/kubectl
-	echo "    finished bin-kubectl" >> $(LOGFILE)
-
-
-#>>>
-# download latest minikube binary from Google repo
-# make bin-minikube
-
-#<<<
-bin-minikube: mkdir
-	echo "    started bin-minikube" >> $(LOGFILE)
-	curl -Lo $(DIR)/bin/minikube \
-		https://storage.googleapis.com/minikube/releases/latest/minikube-$(VENV_OS)-amd64
-	chmod 755 $(DIR)/bin/minikube
-	echo "    finished bin-minikube" >> $(LOGFILE)
 
 
 #>>>

--- a/README.md
+++ b/README.md
@@ -111,11 +111,12 @@ CanDIGv2/
 
 ## `.env` Environment File
 
-The `.env` file in the project root directory contains a set of global variables that are used as reference to
-the various parameters, plugins, and config options that operators can modify for testing purposes.
+You need an `.env` file in the project root directory, which contains a set of global variables that are used as reference to
+the various parameters, plugins, and config options that operators can modify for testing purposes. There is an example `.env` file in `etc/example.env`.
 
 Some of the functionality that is controlled through `.env` are:
 
+* operating system flags
 * change docker network, driver, and swarm host
 * modify ports, protocols, and plugins for various services
 * version control and app pinning

--- a/docs/install-docker.md
+++ b/docs/install-docker.md
@@ -108,7 +108,38 @@ make bin-all
 make init-conda
 ```
 
-## Create CanDIGv2 Development VM
+
+## Choose Docker Deployment Strategy
+
+We provide instructions below for two different docker deployment strategies. Option 1 uses `docker-compose` to deploy each module. Option 2 builds a Docker Swarm cluster using `docker-machine`. We use Option 2 for production, but Option 1 is simpler for local dev installation. 
+
+### Option 1: Deploy CanDIGv2 Services with Compose
+
+The `init-docker` command will initialize CanDIGv2 and set up docker networks, volumes, configs, secrets, and perform other miscellaneous actions needed before deploying a CanDIGv2 stack. Running `init-docker` will override any previous configurations and secrets. 
+
+```bash
+# initialize docker environment
+make init-docker
+
+# (optional) create images
+make images
+
+# pull latest CanDIGv2 images (if you didn't create images locally)
+make docker-pull
+
+# deploy stack 
+make compose
+make init-authx
+# TODO: post deploy auth configuration
+
+# (optional) push updated images to $DOCKER_REGISTRY 
+docker login
+make docker-push
+```
+
+## Option 2: Deploy CanDIGv2 using Docker Swarm 
+
+### Create CanDIGv2 Development VM
 
 Using the provided steps will help to create a `docker-machine` cluster on VirtualBox. The `make` CLI can also be used to provision and connect a multi-vm Swarm cluster. Users are encouraged to use this docker environment for CanDIGv2 development as it provides an isolated domain from the host environment, increasing security and reducing conflicts with host processes. Modify the `MINIKUBE_*` options in `.env`, then launch a single-node or multi-node `docker-machine` with `make machine-$vm_name`, where `$vm_name` is a unique vm name.
 
@@ -119,9 +150,7 @@ To build a development swarm cluster run the following:
 
 To switch your local docker-client to use `docker-machine`, run `eval $(bin/docker-machine env manager)`. Add this line into `bashrc`  with `bin/docker-machine env manager >> $HOME/.bashrc` in order to set `docker-machine` as the default `$DOCKER_HOST` for all shells.
 
-You can move on to the initialize instructions for Docker.
-
-## Initialize CanDIGv2 (Docker)
+### Initialize CanDIGv2 (Docker)
 
 The following commands will initialize CanDIGv2 and set up docker networks, volumes, configs, secrets, and perform other miscellaneous actions needed before deploying a CanDIGv2 stack. Only perform these actions once as it will override any previous configurations and secrets. Once completed, you can deploy a Compose or Swarm stack.
 
@@ -130,35 +159,7 @@ The following commands will initialize CanDIGv2 and set up docker networks, volu
 make init-docker
 ```
 
-## Deploy CanDIGv2 Services (Compose)
-
-```bash
-# create images (optional)
-make images
-
-# pull latest CanDIGv2 images (instead of make images)
-make docker-pull
-
-# deploy stack (if using docker-compose environment)
-make compose
-make init-authx
-# TODO: post deploy auth configuration
-
-# push updated images to $DOCKER_REGISTRY (optional)
-docker login
-make docker-push
-```
-
-## Update hosts
-
-Get your local IP address and edit your /etc/hosts file to add:
-
-```bash
-<your ip>  docker.localhost
-<your ip>  auth.docker.localhost
-```
-
-## Deploy CanDIGv2 Services (Swarm)
+### Deploy using Swarm
 > Note: swarm deployment requires minimum 2 nodes connected (1 manager, 1 worker)
 
 1. Create initial manager node
@@ -186,6 +187,15 @@ docker node ls
 
 # deploy CanDIGv2 services
 make stack
+```
+
+## Update hosts
+
+Get your local IP address and edit your /etc/hosts file to add:
+
+```bash
+<your ip>  docker.localhost
+<your ip>  auth.docker.localhost
 ```
 
 ## Cleanup CanDIGv2 Compose/Swarm Environment

--- a/etc/env/example.env
+++ b/etc/env/example.env
@@ -12,7 +12,7 @@ CANDIG_SITE_LOCATION=UHN
 CANDIG_DEBUG_MODE=1
 
 # miniconda venv
-# options are [linux, darwin]
+# options are [linux, darwin, arm64mac]
 VENV_OS=linux
 VENV_NAME=candig
 VENV_PYTHON=3.7

--- a/etc/env/example.env
+++ b/etc/env/example.env
@@ -92,8 +92,8 @@ CONSUL_DNS_PORT=8600
 CONSUL_LAN_PORT=8301
 CONSUL_WAN_PORT=8302
 
-# traefik controller
-TRAEFIK_VERSION=2.5.0
+# traefik controller, need at least 2.5.1 for mac M1 support
+TRAEFIK_VERSION=2.5.1
 # enable swarm operations
 # options are [true, false]
 TRAEFIK_SWARM=false


### PR DESCRIPTION
This is probably not quite correct in the case of someone trying to install onto an M1 machine with Linux, but for MacOS, this should work.

I also cleaned up the bin-all target and removed deprecated kubernetes stuff.

Don't forget to change the value of VENV_OS in your .env file to `arm64mac`.