### PR TITLE
Update python and pip version to Apple Silicon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,18 +92,18 @@ bin-docker-machine: mkdir
 #<<<
 bin-minio: mkdir
 	echo "    started bin-minio" >> $(LOGFILE)
-	ifeq ($(VENV_OS), arm64mac)
-		curl -Lo $(DIR)/bin/minio \
-			https://dl.minio.io/server/minio/release/darwin-arm64/minio
-		curl -Lo $(DIR)/bin/mc \
-			https://dl.minio.io/client/mc/release/darwin-arm64/mc
-	endif
-	ifneq ($(VENV_OS), arm64mac)
-		curl -Lo $(DIR)/bin/minio \
-			https://dl.minio.io/server/minio/release/$(VENV_OS)-amd64/minio
-		curl -Lo $(DIR)/bin/mc \
-			https://dl.minio.io/client/mc/release/$(VENV_OS)-amd64/mc
-	endif
+ifeq ($(VENV_OS), arm64mac)
+	curl -Lo $(DIR)/bin/minio \
+		https://dl.minio.io/server/minio/release/darwin-arm64/minio
+	curl -Lo $(DIR)/bin/mc \
+		https://dl.minio.io/client/mc/release/darwin-arm64/mc
+endif
+ifneq ($(VENV_OS), arm64mac)
+	curl -Lo $(DIR)/bin/minio \
+		https://dl.minio.io/server/minio/release/$(VENV_OS)-amd64/minio
+	curl -Lo $(DIR)/bin/mc \
+		https://dl.minio.io/client/mc/release/$(VENV_OS)-amd64/mc
+endif
 	chmod 755 $(DIR)/bin/minio
 	chmod 755 $(DIR)/bin/mc
 	echo "    finished bin-minio" >> $(LOGFILE)
@@ -117,14 +117,14 @@ bin-minio: mkdir
 bin-prometheus: mkdir
 	echo "    started bin-prometheus" >> $(LOGFILE)
 	mkdir -p $(DIR)/bin/prometheus
-	ifeq ($(VENV_OS), arm64mac)
-		curl -Lo $(DIR)/bin/prometheus/prometheus.tar.gz \
-			https://github.com/prometheus/prometheus/releases/download/v$(PROMETHEUS_VERSION)/prometheus-$(PROMETHEUS_VERSION).darwin-arm64.tar.gz
-	endif
-	ifneq ($(VENV_OS), arm64mac)
-		curl -Lo $(DIR)/bin/prometheus/prometheus.tar.gz \
-			https://github.com/prometheus/prometheus/releases/download/v$(PROMETHEUS_VERSION)/prometheus-$(PROMETHEUS_VERSION).$(VENV_OS)-amd64.tar.gz
-	endif
+ifeq ($(VENV_OS), arm64mac)
+	curl -Lo $(DIR)/bin/prometheus/prometheus.tar.gz \
+		https://github.com/prometheus/prometheus/releases/download/v$(PROMETHEUS_VERSION)/prometheus-$(PROMETHEUS_VERSION).darwin-arm64.tar.gz
+endif
+ifneq ($(VENV_OS), arm64mac)
+	curl -Lo $(DIR)/bin/prometheus/prometheus.tar.gz \
+		https://github.com/prometheus/prometheus/releases/download/v$(PROMETHEUS_VERSION)/prometheus-$(PROMETHEUS_VERSION).$(VENV_OS)-amd64.tar.gz
+endif
 	tar --strip-components=1 -zxvf $(DIR)/bin/prometheus/prometheus.tar.gz -C $(DIR)/bin/prometheus
 	chmod 755 $(DIR)/bin/prometheus/prometheus
 	echo "    finished bin-prometheus" >> $(LOGFILE)
@@ -137,14 +137,14 @@ bin-prometheus: mkdir
 #<<<
 bin-traefik: mkdir
 	echo "    started bin-traefik" >> $(LOGFILE)
-	ifeq ($(VENV_OS), arm64mac)
-		curl -Lo $(DIR)/bin/miniconda_install.sh \
-			https://github.com/traefik/traefik/releases/download/v$(TRAEFIK_VERSION)/traefik_v$(TRAEFIK_VERSION)_darwin_arm64.tar.gz
-	endif
-	ifneq ($(VENV_OS, arm64mac)
-		curl -Lo $(DIR)/bin/traefik.tar.gz \
-			https://github.com/traefik/traefik/releases/download/v$(TRAEFIK_VERSION)/traefik_v$(TRAEFIK_VERSION)_$(VENV_OS)_amd64.tar.gz
-	endif
+ifeq ($(VENV_OS), arm64mac)
+	curl -Lo $(DIR)/bin/miniconda_install.sh \
+		https://github.com/traefik/traefik/releases/download/v$(TRAEFIK_VERSION)/traefik_v$(TRAEFIK_VERSION)_darwin_arm64.tar.gz
+endif
+ifneq ($(VENV_OS, arm64mac)
+	curl -Lo $(DIR)/bin/traefik.tar.gz \
+		https://github.com/traefik/traefik/releases/download/v$(TRAEFIK_VERSION)/traefik_v$(TRAEFIK_VERSION)_$(VENV_OS)_amd64.tar.gz
+endif
 	tar -xvzf $(DIR)/bin/traefik.tar.gz -C bin/
 	chmod 755 $(DIR)/bin/traefik
 	echo "    finished bin-traefik" >> $(LOGFILE)

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,10 @@ ifeq ($(VENV_OS), darwin)
 	curl -Lo $(DIR)/bin/miniconda_install.sh \
 		https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
 endif
+ifeq ($(VENV_OS), arm64mac)
+	curl -Lo $(DIR)/bin/miniconda_install.sh \
+		https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-arm64.sh
+endif
 	bash $(DIR)/bin/miniconda_install.sh -f -b -u -p $(DIR)/bin/miniconda3
 	# init is needed to create bash aliases for conda but it won't work
 	# until you source the script that ships with conda
@@ -128,10 +132,18 @@ bin-minikube: mkdir
 #<<<
 bin-minio: mkdir
 	echo "    started bin-minio" >> $(LOGFILE)
-	curl -Lo $(DIR)/bin/minio \
-		https://dl.minio.io/server/minio/release/$(VENV_OS)-amd64/minio
-	curl -Lo $(DIR)/bin/mc \
-		https://dl.minio.io/client/mc/release/$(VENV_OS)-amd64/mc
+	ifeq ($(VENV_OS), arm64mac)
+		curl -Lo $(DIR)/bin/minio \
+			https://dl.minio.io/server/minio/release/darwin-arm64/minio
+		curl -Lo $(DIR)/bin/mc \
+			https://dl.minio.io/client/mc/release/darwin-arm64/mc
+	endif
+	ifneq ($(VENV_OS), arm64mac)
+		curl -Lo $(DIR)/bin/minio \
+			https://dl.minio.io/server/minio/release/$(VENV_OS)-amd64/minio
+		curl -Lo $(DIR)/bin/mc \
+			https://dl.minio.io/client/mc/release/$(VENV_OS)-amd64/mc
+	endif
 	chmod 755 $(DIR)/bin/minio
 	chmod 755 $(DIR)/bin/mc
 	echo "    finished bin-minio" >> $(LOGFILE)
@@ -145,8 +157,14 @@ bin-minio: mkdir
 bin-prometheus: mkdir
 	echo "    started bin-prometheus" >> $(LOGFILE)
 	mkdir -p $(DIR)/bin/prometheus
-	curl -Lo $(DIR)/bin/prometheus/prometheus.tar.gz \
-		https://github.com/prometheus/prometheus/releases/download/v$(PROMETHEUS_VERSION)/prometheus-$(PROMETHEUS_VERSION).$(VENV_OS)-amd64.tar.gz
+	ifeq ($(VENV_OS), arm64mac)
+		curl -Lo $(DIR)/bin/prometheus/prometheus.tar.gz \
+			https://github.com/prometheus/prometheus/releases/download/v$(PROMETHEUS_VERSION)/prometheus-$(PROMETHEUS_VERSION).darwin-arm64.tar.gz
+	endif
+	ifneq ($(VENV_OS), arm64mac)
+		curl -Lo $(DIR)/bin/prometheus/prometheus.tar.gz \
+			https://github.com/prometheus/prometheus/releases/download/v$(PROMETHEUS_VERSION)/prometheus-$(PROMETHEUS_VERSION).$(VENV_OS)-amd64.tar.gz
+	endif
 	tar --strip-components=1 -zxvf $(DIR)/bin/prometheus/prometheus.tar.gz -C $(DIR)/bin/prometheus
 	chmod 755 $(DIR)/bin/prometheus/prometheus
 	echo "    finished bin-prometheus" >> $(LOGFILE)
@@ -159,8 +177,14 @@ bin-prometheus: mkdir
 #<<<
 bin-traefik: mkdir
 	echo "    started bin-traefik" >> $(LOGFILE)
-	curl -Lo $(DIR)/bin/traefik.tar.gz \
-		https://github.com/traefik/traefik/releases/download/v$(TRAEFIK_VERSION)/traefik_v$(TRAEFIK_VERSION)_$(VENV_OS)_amd64.tar.gz
+	ifeq ($(VENV_OS), arm64mac)
+		curl -Lo $(DIR)/bin/miniconda_install.sh \
+			https://github.com/traefik/traefik/releases/download/v$(TRAEFIK_VERSION)/traefik_v$(TRAEFIK_VERSION)_darwin_arm64.tar.gz
+	endif
+	ifneq ($(VENV_OS, arm64mac)
+		curl -Lo $(DIR)/bin/traefik.tar.gz \
+			https://github.com/traefik/traefik/releases/download/v$(TRAEFIK_VERSION)/traefik_v$(TRAEFIK_VERSION)_$(VENV_OS)_amd64.tar.gz
+	endif
 	tar -xvzf $(DIR)/bin/traefik.tar.gz -C bin/
 	chmod 755 $(DIR)/bin/traefik
 	echo "    finished bin-traefik" >> $(LOGFILE)

--- a/Makefile
+++ b/Makefile
@@ -97,8 +97,7 @@ ifeq ($(VENV_OS), arm64mac)
 		https://dl.minio.io/server/minio/release/darwin-arm64/minio
 	curl -Lo $(DIR)/bin/mc \
 		https://dl.minio.io/client/mc/release/darwin-arm64/mc
-endif
-ifneq ($(VENV_OS), arm64mac)
+else
 	curl -Lo $(DIR)/bin/minio \
 		https://dl.minio.io/server/minio/release/$(VENV_OS)-amd64/minio
 	curl -Lo $(DIR)/bin/mc \
@@ -120,8 +119,7 @@ bin-prometheus: mkdir
 ifeq ($(VENV_OS), arm64mac)
 	curl -Lo $(DIR)/bin/prometheus/prometheus.tar.gz \
 		https://github.com/prometheus/prometheus/releases/download/v$(PROMETHEUS_VERSION)/prometheus-$(PROMETHEUS_VERSION).darwin-arm64.tar.gz
-endif
-ifneq ($(VENV_OS), arm64mac)
+else
 	curl -Lo $(DIR)/bin/prometheus/prometheus.tar.gz \
 		https://github.com/prometheus/prometheus/releases/download/v$(PROMETHEUS_VERSION)/prometheus-$(PROMETHEUS_VERSION).$(VENV_OS)-amd64.tar.gz
 endif
@@ -140,8 +138,7 @@ bin-traefik: mkdir
 ifeq ($(VENV_OS), arm64mac)
 	curl -Lo $(DIR)/bin/miniconda_install.sh \
 		https://github.com/traefik/traefik/releases/download/v$(TRAEFIK_VERSION)/traefik_v$(TRAEFIK_VERSION)_darwin_arm64.tar.gz
-endif
-ifneq ($(VENV_OS, arm64mac)
+else
 	curl -Lo $(DIR)/bin/traefik.tar.gz \
 		https://github.com/traefik/traefik/releases/download/v$(TRAEFIK_VERSION)/traefik_v$(TRAEFIK_VERSION)_$(VENV_OS)_amd64.tar.gz
 endif

--- a/Makefile
+++ b/Makefile
@@ -43,8 +43,7 @@ mkdir:
 
 #<<<
 .PHONY: bin-all
-bin-all: bin-conda bin-docker-machine bin-kompose bin-kubectl \
-	bin-minikube bin-minio bin-traefik bin-prometheus
+bin-all: bin-conda bin-docker-machine bin-minio bin-traefik bin-prometheus
 
 
 #>>>
@@ -84,45 +83,6 @@ bin-docker-machine: mkdir
 		https://github.com/docker/machine/releases/download/v0.16.2/docker-machine-`uname -s`-`uname -m`
 	chmod 755 $(DIR)/bin/docker-machine
 	echo "    finished bin-docker-machine" >> $(LOGFILE)
-
-
-#>>>
-# download kompose (for kubernetes deployment)
-# make bin-kompose
-
-#<<<
-bin-kompose: mkdir
-	echo "    started bin-kompose" >> $(LOGFILE)
-	curl -Lo $(DIR)/bin/kompose \
-		https://github.com/kubernetes/kompose/releases/download/v1.21.0/kompose-$(VENV_OS)-amd64
-	chmod 755 $(DIR)/bin/kompose
-	echo "    finished bin-kompose" >> $(LOGFILE)
-
-
-#>>>
-# download latest kubectl (for kubernetes deployment)
-# make bin-kubectl
-
-#<<<
-bin-kubectl: mkdir
-	echo "    started bin-kubectl" >> $(LOGFILE)
-	curl -Lo $(DIR)/bin/kubectl \
-		https://storage.googleapis.com/kubernetes-release/release/v1.18.6/bin/$(VENV_OS)/amd64/kubectl
-	chmod 755 $(DIR)/bin/kubectl
-	echo "    finished bin-kubectl" >> $(LOGFILE)
-
-
-#>>>
-# download latest minikube binary from Google repo
-# make bin-minikube
-
-#<<<
-bin-minikube: mkdir
-	echo "    started bin-minikube" >> $(LOGFILE)
-	curl -Lo $(DIR)/bin/minikube \
-		https://storage.googleapis.com/minikube/releases/latest/minikube-$(VENV_OS)-amd64
-	chmod 755 $(DIR)/bin/minikube
-	echo "    finished bin-minikube" >> $(LOGFILE)
 
 
 #>>>

--- a/etc/env/example.env
+++ b/etc/env/example.env
@@ -15,8 +15,8 @@ CANDIG_DEBUG_MODE=1
 # options are [linux, darwin, arm64mac]
 VENV_OS=linux
 VENV_NAME=candig
-VENV_PYTHON=3.7
-VENV_PIP=20.2.4
+VENV_PYTHON=3.9
+VENV_PIP=21.2.2
 
 # docker
 # options are [bridge, bridge-net, ingress, traefik-net]

--- a/etc/env/example.env
+++ b/etc/env/example.env
@@ -12,7 +12,7 @@ CANDIG_SITE_LOCATION=UHN
 CANDIG_DEBUG_MODE=1
 
 # miniconda venv
-# options are [linux, darwin]
+# options are [linux, darwin, arm64mac]
 VENV_OS=linux
 VENV_NAME=candig
 VENV_PYTHON=3.7


### PR DESCRIPTION
This PR based on #154 

- Python bump from 3.7 to 3.9
- Pip bump from 20.2.4 to 21.2.2
This should resolve the error packages not available in conda channels.