### PR TITLE
fix: add compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -377,7 +377,7 @@ compose-%:
 	echo "    started compose-$*" >> $(LOGFILE)
 	cat $(DIR)/lib/compose/docker-compose.yml $(DIR)/lib/logging/$(DOCKER_LOG_DRIVER)/docker-compose.yml \
 		$(DIR)/lib/$*/docker-compose.yml \
-		| docker-compose -f - up -d
+		| docker-compose --compatibility -f - up -d
 	echo "    finished compose-$*" >> $(LOGFILE)
 
 


### PR DESCRIPTION
For Docker Desktop 1.x use _ but 2.x use - when naming. This will option retain the compose compatibility