### PR TITLE
pass in env var for HTSGET_URL

### DIFF
--- a/lib/htsget-server/docker-compose.yml
+++ b/lib/htsget-server/docker-compose.yml
@@ -42,6 +42,7 @@ services:
     logging: *default-logging
     environment:
       HTSGET_TEST_KEY: "hoodlebug"
+      HTSGET_URL: ${HTSGET_PRIVATE_URL}
       OPA_URL: ${OPA_PRIVATE_URL}
       CANDIG_AUTH: ${CANDIG_AUTHORIZATION}
       VAULT_URL: ${VAULT_SERVICE_URL}

--- a/lib/htsget-server/docker-compose.yml
+++ b/lib/htsget-server/docker-compose.yml
@@ -42,7 +42,7 @@ services:
     logging: *default-logging
     environment:
       HTSGET_TEST_KEY: "hoodlebug"
-      HTSGET_URL: ${HTSGET_PRIVATE_URL}
+      HTSGET_URL: ${TYK_LOGIN_TARGET_URL}/${TYK_HTSGET_API_LISTEN_PATH}
       OPA_URL: ${OPA_PRIVATE_URL}
       CANDIG_AUTH: ${CANDIG_AUTHORIZATION}
       VAULT_URL: ${VAULT_SERVICE_URL}


### PR DESCRIPTION
HTSget is an internal API, so the targets are going to be accessed by our own other docker containers. The returned URLs should be privately accessible.

After pulling this and updating to https://github.com/CanDIG/htsget_app/pull/228 (make build-htsget-server, make compose-htsget-server), you can see the results:

```
curl "http://docker.localhost:5080/genomics/htsget/v1/variants/NA18537" \
     -H 'Authorization: Bearer <user1 token>'

{
  "htsget": {
    "format": "VCF",
    "urls": [
      {
        "url": "http://htsget-app:3000/htsget/v1/variants/data/NA18537start=0&end=-1"
      }
    ]
  }
}
```

You might need to add this sample to a dataset that user1 can see:
```
curl -X "POST" "http://docker.localhost:5080/genomics/ga4gh/drs/v1/datasets" \
     -H 'Content-Type: application/json' \
     -H 'Authorization: Bearer <user2 (site admin) token>' \
     -d $'{
  "id": "controlled4",
  "drsobjects": [
    "drs://localhost/NA18537"
  ]
}'
```