### PR TITLE
DIG-931: Vault aws policy needs update permissions

### DIFF
--- a/lib/htsget-server/docker-compose.yml
+++ b/lib/htsget-server/docker-compose.yml
@@ -44,6 +44,7 @@ services:
       HTSGET_TEST_KEY: "hoodlebug"
       HTSGET_URL: ${TYK_LOGIN_TARGET_URL}/${TYK_HTSGET_API_LISTEN_PATH}
       OPA_URL: ${OPA_PRIVATE_URL}
+      OPA_SITE_ADMIN_KEY: ${OPA_SITE_ADMIN_KEY} # only required if not equal to "site_admin"
       CANDIG_AUTH: ${CANDIG_AUTHORIZATION}
       VAULT_URL: ${VAULT_SERVICE_URL}
       DEBUG_MODE: ${CANDIG_DEBUG_MODE}

--- a/lib/vault/vault_setup.sh
+++ b/lib/vault/vault_setup.sh
@@ -93,7 +93,7 @@ docker exec $vault sh -c "echo 'path \"identity/oidc/token/*\" {capabilities = [
 
 echo
 echo ">> setting up aws policy"
-docker exec $vault sh -c "echo 'path \"aws/*\" {capabilities = [\"create\", \"read\"]}' >> vault-policy.hcl; vault policy write aws vault-policy.hcl"
+docker exec $vault sh -c "echo 'path \"aws/*\" {capabilities = [\"create\", \"update\", \"read\"]}' >> vault-policy.hcl; vault policy write aws vault-policy.hcl"
 
 # user claims
 echo


### PR DESCRIPTION
Also added in an env var to be passed in for htsget; it is optional so no change to test.