### PR TITLE
Remove candig server and update module list

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,13 +67,13 @@ Not all CanDIG modules are required for a minimal installation. The `CANDIG_MODU
 
 By default (if you copy the sample file from `etc/env/example.env`) the installation includes the minimal list of modules:
 
-  CANDIG_MODULES=minio htsget-server chord-metadata candig-server candig-data-portal
+  CANDIG_MODULES=minio htsget-server chord-metadata candig-data-portal
 
 Optional modules follow the `#` and include federation service, various monitoring components, workflow execution, and some older modules not generally installed. 
 
 For federated installations, you will need `federation-service`. 
 
-For production deployments, you will probably want _add prod modules here_.
+For production deployments, you will probably want to include  `federation-service weavescope logging monitoring`. Be aware that the last three require more resources, includeing storage. 
 
 Authorization and authentication modules defined in  `CANDIG_AUTH_MODULES` are only installed if you run `make init-authx` during deployment. 
 

--- a/etc/env/example.env
+++ b/etc/env/example.env
@@ -2,7 +2,7 @@
 # - - -
 
 # site options
-CANDIG_MODULES=minio htsget-server chord-metadata candig-server candig-data-portal #drs-server wes-server jupyter igv-js traefik portainer consul logging monitoring datasets cnv-service rnaget federation-service
+CANDIG_MODULES=minio htsget-server chord-metadata candig-data-portal #drs-server wes-server jupyter igv-js traefik portainer consul logging monitoring datasets cnv-service rnaget federation-service
 CANDIG_AUTH_MODULES=keycloak tyk opa vault
 
 # options are [<ip_addr>, <url>, host.docker.internal, docker.localhost]


### PR DESCRIPTION
Removing candig-server from the example .env file and updating the readme with the minimal and production list of modules. 