### PR TITLE
DIG-996: Automate /etc/hosts step during init-authx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 /etc/ssl/selfsigned-*
 */miniconda3
 .vagrant
+.hosts.tmp
 
 # test metadata
 etc/tests/integration/*/__pycache__/*

--- a/Makefile
+++ b/Makefile
@@ -244,6 +244,13 @@ docker-secrets: mkdir minio-secrets
 	$(MAKE) secret-opa-root-token
 	$(MAKE) secret-opa-service-token
 
+#>>>
+# modify the hosts file
+
+#<<<
+.PHONY: hosts-file
+hosts-file:
+	source ${PWD}/setup_hosts.sh
 
 #>>>
 # create persistant volumes for docker containers
@@ -306,7 +313,7 @@ init-conda:
 
 #<<<
 .PHONY: init-docker
-init-docker: docker-volumes docker-secrets
+init-docker: docker-volumes docker-secrets hosts-file
 
 
 #>>>

--- a/Makefile
+++ b/Makefile
@@ -248,8 +248,8 @@ docker-secrets: mkdir minio-secrets
 # modify the hosts file
 
 #<<<
-.PHONY: hosts-file
-hosts-file:
+.PHONY: init-hosts-file
+init-hosts-file:
 	source ${PWD}/setup_hosts.sh
 
 #>>>
@@ -313,7 +313,7 @@ init-conda:
 
 #<<<
 .PHONY: init-docker
-init-docker: docker-volumes docker-secrets hosts-file
+init-docker: docker-volumes docker-secrets
 
 
 #>>>

--- a/docs/install-docker.md
+++ b/docs/install-docker.md
@@ -1,7 +1,7 @@
 # CanDIGv2 Install Guide
 
 ---
-These instructions work for server deployments or local linux deployments. For local OSX using M1 architecture, follow the [Mac Apple Silicon Installation](#mac-apple-silicon-installation) instructions at the bottom of this file. For WSL you can follow the linux instructions and follow WSL instructions for updating your firewall at [update firewall](#update-firewall).
+These instructions work for server deployments or local linux deployments. For local OSX using M1 architecture, follow the [Mac Apple Silicon Installation](#mac-apple-silicon-installation) instructions at the bottom of this file. For WSL you can follow the linux instructions and follow WSL instructions for firewall file at [update firewall](#update-firewall).
 
 Before beginning, you should set up your environment variables as described in the [README](README.md).
 
@@ -111,10 +111,6 @@ make bin-conda
 make init-conda
 ```
 
-## Update Firewall
-
-We provide instructions below for two different docker deployment strategies. Option 1 uses `docker-compose` to deploy each module. Option 2 builds a Docker Swarm cluster using `docker-machine`. We use Option 2 for production, but Option 1 is simpler for local dev installation. It may be necessary to configure your firewall file before proceeding (i.e. if you run into an error during `make init-authx`), check the [Firewall documentation](#update-firewall).
-
 ##  Deploy CanDIGv2 Services with Compose
 
 The `init-docker` command will initialize CanDIGv2 and set up docker networks, volumes, configs, secrets, and perform other miscellaneous actions needed before deploying a CanDIGv2 stack. Running `init-docker` will override any previous configurations and secrets.
@@ -133,67 +129,9 @@ make init-authx # If this command fails, try the #update-firewall section of thi
 
 ```
 
+## Update Firewall
+
 If the command still fails, it may be necessary to disable your local firewall, or edit it to allow requests from all ports used in the Docker stack.
-
-## Option 2: Deploy CanDIGv2 using Docker Swarm
-
-### Create CanDIGv2 Development VM
-
-Using the provided steps will help to create a `docker-machine` cluster on VirtualBox. The `make` CLI can also be used to provision and connect a multi-vm Swarm cluster. Users are encouraged to use this docker environment for CanDIGv2 development as it provides an isolated domain from the host environment, increasing security and reducing conflicts with host processes. Modify the `MINIKUBE_*` options in `.env`, then launch a single-node or multi-node `docker-machine` with `make machine-$vm_name`, where `$vm_name` is a unique vm name.
-
-To build a development swarm cluster run the following:
-
-- create a swarm manager with `make machine-manager`, additional nodes with `make machine-manager2`...
-- create a swarm worker with `make machine-worker`, additional nodes with `make machine-worker2`...
-
-To switch your local docker-client to use `docker-machine`, run `eval $(bin/docker-machine env manager)`. Add this line into `bashrc` with `bin/docker-machine env manager >> $HOME/.bashrc` in order to set `docker-machine` as the default `$DOCKER_HOST` for all shells.
-
-### Initialize CanDIGv2 (Docker)
-
-The following commands will initialize CanDIGv2 and set up docker networks, volumes, configs, secrets, and perform other miscellaneous actions needed before deploying a CanDIGv2 stack. Only perform these actions once as it will override any previous configurations and secrets. Once completed, you can deploy a Compose or Swarm stack.
-
-```bash
-# initialize docker environment
-make init-docker
-```
-
-### Deploy using Swarm
-
-> Note: swarm deployment requires minimum 2 nodes connected (1 manager, 1 worker)
-
-1. Create initial manager node
-
-```bash
-eval $(bin/docker-machine env manager)
-make init-swarm
-```
-
-2. Add additional manager/worker nodes
-
-```bash
-# set the SWARM_MODE and SWARM_MANAGER_IP in .env
-eval $(bin/docker-machine env worker)
-make swarm-join
-```
-
-3. Deploy CanDIGv2 stack on the docker swarm
-
-```bash
-eval $(bin/docker-machine env manager)
-
-# check cluster status (READY:ACTIVE)
-docker node ls
-
-# deploy CanDIGv2 services
-make stack
-```
-
-## Update firewall
-
-It may be necessary to disable your local firewall, or edit it to allow requests from all ports used in the Docker stack. 
-
-Example (Ubuntu):
-Go to your `.env` file and write down the IP addresses for DOCKER_BRIDGE_IP and DOCKER_GWBRIDGE_IP.
 
 Edit your firewall settings to allow connections from those adresses:
 ```bash

--- a/docs/install-docker.md
+++ b/docs/install-docker.md
@@ -119,6 +119,9 @@ The `init-docker` command will initialize CanDIGv2 and set up docker networks, v
 # initialize docker environment
 make init-docker
 
+# Setup required local redirect
+make init-hosts-file
+
 # pull latest CanDIGv2 images (if you didn't create images locally)
 make docker-pull
 
@@ -224,6 +227,7 @@ conda activate {path_to_folder}/CanDIGv2/bin/miniconda3/envs/candig
 
 ```bash
 make init-docker
+make init-hosts-file # Setup required local redirect
 ```
 
 ### Step 4: Deploy CanDIGv2 Services (Compose)

--- a/lib/vault/vault_setup.sh
+++ b/lib/vault/vault_setup.sh
@@ -19,21 +19,6 @@ mkdir -p ${PWD}/lib/vault/tmp
 echo "Working on vault-config.json .."
 envsubst < ${PWD}/lib/vault/configuration_templates/vault-config.json.tpl > ${PWD}/lib/vault/tmp/vault-config.json
 
-# Replace docker.localhost entry in /etc/hosts
-echo "Replacing the docker.localhost entry in /etc/hosts (root access will be requried)..."
-sudo grep -v "	docker\.localhost" /etc/hosts >.hosts.tmp
-sudo printf "\n" >>.hosts.tmp
-
-if [ "$VENV_OS" == "linux" ]
-then
-  sudo ifconfig | grep -A 1 'wlp0\|eth0' | grep -o "inet [0-9.]\+" | cut -d' ' -f2 | tr -d $'\n' >>.hosts.tmp
-  sudo printf "\tdocker.localhost" >> .hosts.tmp
-else
-  sudo ifconfig en0 | grep -o "inet [0-9.]\+" | cut -d' ' -f2 | tr -d $'\n' >>.hosts.tmp
-  sudo printf "\tdocker.localhost" >> .hosts.tmp
-fi
-sudo mv .hosts.tmp /etc/hosts
-
 # boot container
 make build-vault
 make compose-vault

--- a/lib/vault/vault_setup.sh
+++ b/lib/vault/vault_setup.sh
@@ -21,18 +21,18 @@ envsubst < ${PWD}/lib/vault/configuration_templates/vault-config.json.tpl > ${PW
 
 # Replace docker.localhost entry in /etc/hosts
 echo "Replacing the docker.localhost entry in /etc/hosts (root access will be requried)..."
-sudo grep -v "	docker\.localhost" /etc/hosts >hosts.tmp
-sudo printf "\n" >>hosts.tmp
+sudo grep -v "	docker\.localhost" /etc/hosts >.hosts.tmp
+sudo printf "\n" >>.hosts.tmp
 
 if [ "$VENV_OS" == "linux" ]
 then
-  sudo ifconfig | grep -A 1 'wlp0\|eth0' | grep -o "inet [0-9.]\+" | cut -d' ' -f2 | tr -d $'\n' >>hosts.tmp
-  sudo printf "\tdocker.localhost" >> hosts.tmp
+  sudo ifconfig | grep -A 1 'wlp0\|eth0' | grep -o "inet [0-9.]\+" | cut -d' ' -f2 | tr -d $'\n' >>.hosts.tmp
+  sudo printf "\tdocker.localhost" >> .hosts.tmp
 else
-  sudo ifconfig en0 | grep -Eo "inet [0-9.]\+" | cut -d' ' -f2 >>hosts.tmp
-  sudo printf "\tdocker.localhost" >> hosts.tmp
+  sudo ifconfig en0 | grep -o "inet [0-9.]\+" | cut -d' ' -f2 | tr -d $'\n' >>.hosts.tmp
+  sudo printf "\tdocker.localhost" >> .hosts.tmp
 fi
-sudo mv hosts.tmp /etc/hosts
+sudo mv .hosts.tmp /etc/hosts
 
 # boot container
 make build-vault

--- a/lib/vault/vault_setup.sh
+++ b/lib/vault/vault_setup.sh
@@ -19,6 +19,21 @@ mkdir -p ${PWD}/lib/vault/tmp
 echo "Working on vault-config.json .."
 envsubst < ${PWD}/lib/vault/configuration_templates/vault-config.json.tpl > ${PWD}/lib/vault/tmp/vault-config.json
 
+# Replace docker.localhost entry in /etc/hosts
+echo "Replacing the docker.localhost entry in /etc/hosts (root access will be requried)..."
+sudo grep -v "	docker\.localhost" /etc/hosts >hosts.tmp
+sudo printf "\n" >>hosts.tmp
+
+if [ "$VENV_OS" == "linux" ]
+then
+  sudo ifconfig | grep -A 1 'wlp0\|eth0' | grep -o "inet [0-9.]\+" | cut -d' ' -f2 | tr -d $'\n' >>hosts.tmp
+  sudo printf "\tdocker.localhost" >> hosts.tmp
+else
+  sudo ifconfig en0 | grep -Eo "inet [0-9.]\+" | cut -d' ' -f2 >>hosts.tmp
+  sudo printf "\tdocker.localhost" >> hosts.tmp
+fi
+sudo mv hosts.tmp /etc/hosts
+
 # boot container
 make build-vault
 make compose-vault

--- a/setup_hosts.sh
+++ b/setup_hosts.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# Early-abort if this step isn't required
+test=$(grep "	docker\.localhost" /etc/hosts)
+
+if [[ ! -z "$test" ]]; then
+    echo "Skipping hosts setup as docker.localhosts already exists there..."
+    exit 0
+fi
+
+# Replace docker.localhost entry in /etc/hosts
+echo "HACK ALERT"
+echo "This step will introduce an entry into /etc/hosts so that requests to docker.localhost"
+echo "will bounce off your local step. Root access will be required..."
+cp /etc/hosts .hosts.tmp
+printf "\n" >>.hosts.tmp
+
+if [ "$VENV_OS" == "linux" ]; then
+  IP=$(ifconfig | grep -A 1 'wlp0\|eth0' | grep -o "inet [0-9.]\+" | cut -d' ' -f2)
+else
+  IP=$(ifconfig | grep -o "inet [0-9.]\+" | cut -d' ' -f2)
+fi
+
+numlines=$(echo "$IP" | wc -l)
+if [ "$numlines" == "1" ]; then
+    printf "$IP\tdocker.localhost" >> .hosts.tmp
+    sudo mv .hosts.tmp /etc/hosts;
+else
+    echo "More than one IP has been detected. Since this script can't automatically determine which one"
+    echo "will make the build work, please remove all but one of the inserted docker.localhost lines in /etc/hosts."
+    echo $IP >.hosts.tmp2
+    awk '{printf "%s\tdocker.localhost\n", $0}' .hosts.tmp2 >> .hosts.tmp
+    rm .hosts.tmp2
+    sudo mv .hosts.tmp /etc/hosts;
+fi

--- a/setup_hosts.sh
+++ b/setup_hosts.sh
@@ -11,25 +11,25 @@ fi
 # Replace docker.localhost entry in /etc/hosts
 echo "HACK ALERT"
 echo "This step will introduce an entry into /etc/hosts so that requests to docker.localhost"
-echo "will bounce off your local step. Root access will be required..."
+echo "will bounce off your local network. Root access will be required..."
 cp /etc/hosts .hosts.tmp
 printf "\n" >>.hosts.tmp
 
 if [ "$VENV_OS" == "linux" ]; then
-  IP=$(ifconfig | grep -A 1 'wlp0\|eth0' | grep -o "inet [0-9.]\+" | cut -d' ' -f2)
+  ifconfig | grep -A 1 'wlp0\|eth0' | grep -o "inet [0-9.]\+" | cut -d' ' -f2 > .hosts.tmp2
 else
-  IP=$(ifconfig | grep -o "inet [0-9.]\+" | cut -d' ' -f2)
+  ifconfig | grep -o "inet [0-9.]\+" | cut -d' ' -f2 > .hosts.tmp2
 fi
 
-numlines=$(echo "$IP" | wc -l)
+numlines=$(wc -l .hosts.tmp2)
 if [ "$numlines" == "1" ]; then
     printf "$IP\tdocker.localhost" >> .hosts.tmp
     sudo mv .hosts.tmp /etc/hosts;
+    rm .hosts.tmp2;
 else
     echo "ERROR: More than one IP has been detected. Since this script can't automatically determine which one"
     echo "will make the build work, please remove all but one of the inserted docker.localhost lines in /etc/hosts."
-    echo $IP >.hosts.tmp2
     awk '{printf "%s\tdocker.localhost\n", $0}' .hosts.tmp2 >> .hosts.tmp
-    rm .hosts.tmp2
     sudo mv .hosts.tmp /etc/hosts;
+    rm .hosts.tmp2;
 fi

--- a/setup_hosts.sh
+++ b/setup_hosts.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Early-abort if this step isn't required
-test=$(grep "	docker\.localhost" /etc/hosts)
+test=$(grep -E "\sdocker\.localhost" /etc/hosts)
 
 if [[ ! -z "$test" ]]; then
     echo "Skipping hosts setup as docker.localhosts already exists there..."
@@ -26,7 +26,7 @@ if [ "$numlines" == "1" ]; then
     printf "$IP\tdocker.localhost" >> .hosts.tmp
     sudo mv .hosts.tmp /etc/hosts;
 else
-    echo "More than one IP has been detected. Since this script can't automatically determine which one"
+    echo "ERROR: More than one IP has been detected. Since this script can't automatically determine which one"
     echo "will make the build work, please remove all but one of the inserted docker.localhost lines in /etc/hosts."
     echo $IP >.hosts.tmp2
     awk '{printf "%s\tdocker.localhost\n", $0}' .hosts.tmp2 >> .hosts.tmp


### PR DESCRIPTION
[Jira link](https://candig.atlassian.net/browse/DIG-996)

This automates the inclusion of the `/etc/hosts` file into the `make init-authx` step. Includes the removal of documentation related to the step.

To test:
- [x] Linux build
- [x] Windows build
- [x] MacOS build