### PR TITLE
docker compose instead of docker-compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ endif
 build-%:
 	echo "    started build-$*" >> $(LOGFILE)
 	DOCKER_BUILDKIT=1 COMPOSE_DOCKER_CLI_BUILD=1 \
-	docker-compose -f $(DIR)/lib/candigv2/docker-compose.yml -f $(DIR)/lib/$*/docker-compose.yml build $(BUILD_OPTS)
+	docker compose -f $(DIR)/lib/candigv2/docker-compose.yml -f $(DIR)/lib/$*/docker-compose.yml build $(BUILD_OPTS)
 	echo "    finished build-$*" >> $(LOGFILE)
 
 
@@ -133,7 +133,7 @@ clean-bin:
 .PHONY: clean-compose
 clean-compose:
 	$(foreach MODULE, $(CANDIG_MODULES), \
-		docker-compose -f $(DIR)/lib/candigv2/docker-compose.yml -f $(DIR)/lib/$(MODULE)/docker-compose.yml down || true;)
+		docker compose -f $(DIR)/lib/candigv2/docker-compose.yml -f $(DIR)/lib/$(MODULE)/docker-compose.yml down || true;)
 
 
 #>>>
@@ -208,7 +208,7 @@ compose:
 #<<<
 compose-%:
 	echo "    started compose-$*" >> $(LOGFILE)
-	docker-compose -f $(DIR)/lib/candigv2/docker-compose.yml -f $(DIR)/lib/$*/docker-compose.yml --compatibility up -d
+	docker compose -f $(DIR)/lib/candigv2/docker-compose.yml -f $(DIR)/lib/$*/docker-compose.yml --compatibility up -d
 	echo "    finished compose-$*" >> $(LOGFILE)
 
 
@@ -347,7 +347,7 @@ minio-secrets:
 
 #<<<
 pull-%:
-		docker-compose -f $(DIR)/lib/candigv2/docker-compose.yml -f $(DIR)/lib/$*/docker-compose.yml pull
+		docker compose -f $(DIR)/lib/candigv2/docker-compose.yml -f $(DIR)/lib/$*/docker-compose.yml pull
 
 
 #>>>
@@ -357,7 +357,7 @@ pull-%:
 
 #<<<
 push-%:
-		docker-compose -f $(DIR)/lib/candigv2/docker-compose.yml -f $(DIR)/lib/$*/docker-compose.yml push
+		docker compose -f $(DIR)/lib/candigv2/docker-compose.yml -f $(DIR)/lib/$*/docker-compose.yml push
 
 
 #>>>

--- a/Makefile.authx
+++ b/Makefile.authx
@@ -4,7 +4,7 @@
 
 #<<<
 clean-keycloak:
-	docker-compose -f $(DIR)/lib/candigv2/docker-compose.yml -f $(DIR)/lib/keycloak/docker-compose.yml down || true
+	docker compose -f $(DIR)/lib/candigv2/docker-compose.yml -f $(DIR)/lib/keycloak/docker-compose.yml down || true
 
 	# - remove intermittent docker images
 	@eval docker images --format '{{.Repository}}:{{.Tag}}' | grep 'keycloak' | xargs -I{} docker rmi --force {}
@@ -17,7 +17,7 @@ clean-keycloak:
 
 #<<<
 clean-vault:
-	docker-compose -f $(DIR)/lib/candigv2/docker-compose.yml -f $(DIR)/lib/vault/docker-compose.yml down || true
+	docker compose -f $(DIR)/lib/candigv2/docker-compose.yml -f $(DIR)/lib/vault/docker-compose.yml down || true
 
 	# - remove intermittent docker images
 	@eval docker images --format '{{.Repository}}:{{.Tag}}' | grep 'vault' | xargs -I{} docker rmi --force {}
@@ -31,7 +31,7 @@ clean-vault:
 
 #<<<
 clean-opa:
-	docker-compose -f $(DIR)/lib/candigv2/docker-compose.yml -f $(DIR)/lib/opa/docker-compose.yml down || true
+	docker compose -f $(DIR)/lib/candigv2/docker-compose.yml -f $(DIR)/lib/opa/docker-compose.yml down || true
 
 	# - remove intermittent docker images
 	@eval docker images --format '{{.Repository}}:{{.Tag}}' | grep 'openpolicyagent/opa' | xargs -I{} docker rmi --force {}
@@ -46,7 +46,7 @@ clean-opa:
 
 #<<<
 clean-tyk:
-	docker-compose -f $(DIR)/lib/candigv2/docker-compose.yml -f $(DIR)/lib/tyk/docker-compose.yml down || true
+	docker compose -f $(DIR)/lib/candigv2/docker-compose.yml -f $(DIR)/lib/tyk/docker-compose.yml down || true
 
 	# - remove intermittent docker images
 	docker images --format '{{.Repository}}:{{.Tag}}' | grep -E 'tyk|redis' |  xargs -I{} docker rmi --force {}

--- a/lib/candig-data-portal/docker-compose.yml
+++ b/lib/candig-data-portal/docker-compose.yml
@@ -14,6 +14,8 @@ services:
         target: vault-s3-token
       - source: opa-service-token
         target: opa-service-token
+    extra_hosts:
+        - "docker.localhost:${LOCAL_IP_ADDR}"
     environment:
       - REACT_APP_KATSU_API_SERVER=${CHORD_METADATA_PUBLIC_URL}
       - REACT_APP_HTSGET_SERVER=${HTSGET_PUBLIC_URL}

--- a/lib/chord-metadata/docker-compose.yml
+++ b/lib/chord-metadata/docker-compose.yml
@@ -12,6 +12,8 @@ services:
       - "${CHORD_METADATA_PORT}:8000"
     depends_on:
       - metadata-db
+    extra_hosts:
+      - "docker.localhost:${LOCAL_IP_ADDR}"
     environment:
       - POSTGRES_HOST=metadata-db
       - POSTGRES_PORT=5432
@@ -36,6 +38,8 @@ services:
       - POSTGRES_DB=metadata
       - POSTGRES_PASSWORD_FILE=/run/secrets/metadata_db_secret
       - POSTGRES_HOST_AUTH_METHOD=password
+    extra_hosts:
+      - "docker.localhost:${LOCAL_IP_ADDR}"
     secrets:
       - source: metadata-db-secret
         target: metadata_db_secret

--- a/lib/federation-service/docker-compose.yml
+++ b/lib/federation-service/docker-compose.yml
@@ -15,4 +15,6 @@ services:
         target: /app/federation_service/configs/servers.json
       - source: federation-services
         target: /app/federation_service/configs/services.json
+    extra_hosts:
+        - "docker.localhost:${LOCAL_IP_ADDR}"
     entrypoint: ["uwsgi", "federation.ini", "--http", "0.0.0.0:4232"]

--- a/lib/htsget-server/docker-compose.yml
+++ b/lib/htsget-server/docker-compose.yml
@@ -27,4 +27,6 @@ services:
       DEBUG_MODE: ${CANDIG_DEBUG_MODE}
       DB_PATH: /data/files.db
       TESTENV_URL: ${HTSGET_PRIVATE_URL}
+    extra_hosts:
+      - "docker.localhost:${LOCAL_IP_ADDR}"
     command: ["--host", "0.0.0.0", "--port", "3000"]

--- a/lib/minio/docker-compose.yml
+++ b/lib/minio/docker-compose.yml
@@ -17,6 +17,8 @@ services:
         target: access_key
       - source: minio-secret-key
         target: secret_key
+    extra_hosts:
+        - "docker.localhost:${LOCAL_IP_ADDR}"
     command: ["server", "/data","--console-address", ":${MINIO_UI_PORT}"]
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]


### PR DESCRIPTION
I found that I needed to specify `docker compose` instead of `docker-compose` to have the steps run with compose-v2 instead of v1. More info is here: https://docs.docker.com/compose/compose-v2/