### PR TITLE
Fix a bug where make compose-% was missing the IP address

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -210,6 +210,7 @@ compose:
 #<<<
 compose-%:
 	echo "    started compose-$*" >> $(LOGFILE)
+	source ${PWD}/setup_hosts.sh; \
 	docker compose -f $(DIR)/lib/candigv2/docker-compose.yml -f $(DIR)/lib/$*/docker-compose.yml --compatibility up -d
 	echo "    finished compose-$*" >> $(LOGFILE)
 

--- a/setup_hosts.sh
+++ b/setup_hosts.sh
@@ -5,10 +5,6 @@ if [[ ! -z ${LOCAL_IP_ADDR:-} ]]; then
     echo "IP Address is already set to: $LOCAL_IP_ADDR"
     return
 fi
-if [[ "$CANDIG_DOMAIN" != "docker.localhost" ]]; then
-    echo "Hosts step not required when CANDIG_DOMAIN != docker.localhost"
-    return
-fi
 
 # Replace docker.localhost entry in /etc/hosts
 if [ "$VENV_OS" == "linux" ]; then


### PR DESCRIPTION
Bugfix a regression introduced by #203 where the `make compose-%` command was failing due to the missing environment variable.

**To test**: Attempt to bring a module down, then back up with `make compose-candig-data-portal` (for instance)