### PR TITLE
Label PostGres + Vault volumes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -286,6 +286,7 @@ docker-volumes:
 	docker volume create vault-data --label candigv2=volume
 	docker volume create opa-data --label candigv2=volume
 	docker volume create htsget-data --label candigv2=volume
+	docker volume create postgres-data --label candigv2=volume
 
 
 #>>>

--- a/lib/candigv2/docker-compose.yml
+++ b/lib/candigv2/docker-compose.yml
@@ -23,6 +23,8 @@ volumes:
     external: true
   htsget-data:
     external: true
+  postgres-data:
+    external: true
 
 secrets:
   aws-credentials:

--- a/lib/chord-metadata/docker-compose.yml
+++ b/lib/chord-metadata/docker-compose.yml
@@ -44,6 +44,8 @@ services:
       - POSTGRES_HOST_AUTH_METHOD=password
     extra_hosts:
       - "docker.localhost:${LOCAL_IP_ADDR}"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
     secrets:
       - source: metadata-db-secret
         target: metadata_db_secret


### PR DESCRIPTION
This PR labels one of the volumes that were discovered to be unlabeled during testing of #208 -- one from Postgres. There's two more from Vault one that I cannot specify ([/vault/file and /vault/logs](https://hub.docker.com/_/vault)) that I cannot specify without the vault setup going awry.

The effect of this PR is that when you run `make compose; make init-authx`, there is one less unlabelled volumes created, and these will be properly deleted with `make clean-all`.