### PR TITLE
Test htsget inside its container

### DIFF
--- a/lib/htsget-server/docker-compose.yml
+++ b/lib/htsget-server/docker-compose.yml
@@ -24,7 +24,6 @@ services:
       HTSGET_URL: ${TYK_LOGIN_TARGET_URL}/${TYK_HTSGET_API_LISTEN_PATH}
       OPA_URL: ${OPA_PRIVATE_URL}
       OPA_SITE_ADMIN_KEY: ${OPA_SITE_ADMIN_KEY} # only required if not equal to "site_admin"
-      CANDIG_AUTH: ${CANDIG_AUTHORIZATION}
       VAULT_URL: ${VAULT_SERVICE_URL}
       DEBUG_MODE: ${CANDIG_DEBUG_MODE}
       DB_PATH: /data/files.db

--- a/lib/htsget-server/docker-compose.yml
+++ b/lib/htsget-server/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       HTSGET_URL: ${TYK_LOGIN_TARGET_URL}/${TYK_HTSGET_API_LISTEN_PATH}
       OPA_URL: ${OPA_PRIVATE_URL}
       OPA_SITE_ADMIN_KEY: ${OPA_SITE_ADMIN_KEY} # only required if not equal to "site_admin"
-      VAULT_URL: ${VAULT_SERVICE_URL}
+      CANDIG_VAULT_URL: ${VAULT_SERVICE_URL}
       MINIO_URL: ${MINIO_PRIVATE_URL}
       DEBUG_MODE: ${CANDIG_DEBUG_MODE}
       DB_PATH: /data/files.db

--- a/lib/htsget-server/docker-compose.yml
+++ b/lib/htsget-server/docker-compose.yml
@@ -19,12 +19,17 @@ services:
         target: vault-s3-token
       - source: opa-service-token
         target: opa-service-token
+      - source: minio-access-key
+        target: minio-access-key
+      - source: minio-secret-key
+        target: minio-secret-key
     environment:
       HTSGET_TEST_KEY: "hoodlebug"
       HTSGET_URL: ${TYK_LOGIN_TARGET_URL}/${TYK_HTSGET_API_LISTEN_PATH}
       OPA_URL: ${OPA_PRIVATE_URL}
       OPA_SITE_ADMIN_KEY: ${OPA_SITE_ADMIN_KEY} # only required if not equal to "site_admin"
       VAULT_URL: ${VAULT_SERVICE_URL}
+      MINIO_URL: ${MINIO_PRIVATE_URL}
       DEBUG_MODE: ${CANDIG_DEBUG_MODE}
       DB_PATH: /data/files.db
       TESTENV_URL: ${HTSGET_PRIVATE_URL}


### PR DESCRIPTION
This PR includes changes to htsget to allow one to run pytest inside the container.

To test:
* Rebuild htsget (`make build-htsget-server`, `make compose-htsget-server`)
* Run pytest inside the container (`docker exec -it candigv2_htsget-app_1 pytest`)
* Verify that pytest still works outside the container (`pytest lib/htsget-server/htsget_app/tests/`)