### PR TITLE
DIG-1133: changing CANDIG_DOMAIN from docker.localhost to candig.docker.internal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,7 @@ build-all:
 
 # Setup the entire stack
 	$(MAKE) init-docker
+	$(MAKE) init-conda
 	$(MAKE) build-images
 	$(MAKE) compose
 	$(MAKE) init-authx

--- a/docs/ingest-and-test.md
+++ b/docs/ingest-and-test.md
@@ -4,13 +4,13 @@ These instructions will lead you through some basic functionality tests, ingesti
 
 ## Initial tests
 
-Check that you can see the data portal in your browser at `http://docker.localhost:5080/`. If not, you may need to follow the instructions in the [Docker Deployment Guide](./install-docker.md)
+Check that you can see the data portal in your browser at `http://candig.docker.internal:5080/`. If not, you may need to follow the instructions in the [Docker Deployment Guide](./install-docker.md)
 
 Check that you can generate a bearer token for user2 with the following call, substituting usernames, secrets and passwords from `tmp/secrets/keycloak-test-user2`, `tmp/secrets/keycloak-client-local_candig-secret` and `tmp/secrets/keycloak-test-user2-password`.
 
 ```bash
 ## user2 bearer token
-curl -X "POST" "http://docker.localhost:8080/auth/realms/candig/protocol/openid-connect/token" \
+curl -X "POST" "http://candig.docker.internal:8080/auth/realms/candig/protocol/openid-connect/token" \
      -H 'Content-Type: application/x-www-form-urlencoded; charset=utf-8' \
      --data-urlencode "client_id=local_candig" \
      --data-urlencode "client_secret=<client_secret>" \
@@ -33,7 +33,7 @@ Federation service is required to run most of CanDig operations. The following e
 {
     "servers": [
         {
-            "url": "http://docker.localhost:4232/federation/search",
+            "url": "http://candig.docker.internal:4232/federation/search",
             "location": [
                 "UHN",
                 "Ontario",
@@ -49,9 +49,9 @@ and `services.json`
 ```json
 {
     "services": {
-        "katsu": "http://docker.localhost:5080/katsu",
-        "candig-server": "http://docker.localhost:5080/candig",
-        "htsget-app": "http://docker.localhost:5080/genomics"
+        "katsu": "http://candig.docker.internal:5080/katsu",
+        "candig-server": "http://candig.docker.internal:5080/candig",
+        "htsget-app": "http://candig.docker.internal:5080/genomics"
     }
 }
 ```
@@ -98,14 +98,14 @@ make compose-federation-service
 ```
 To check that it is running you can look at the candigv2_federation-service_1 container in your Window Docker GUI. You can also run the following in terminal:
 ```bash
-curl http://docker.localhost:4232/federation/services
+curl http://candig.docker.internal:4232/federation/services
 ```
 The below is an example of what will return it should be what is in your services.json
 ```json
 {
-  "candig-server": "http://docker.localhost:5080/candig",
-  "htsget-app": "http://docker.localhost:5080/genomics",
-  "katsu": "http://docker.localhost:5080/katsu"
+  "candig-server": "http://candig.docker.internal:5080/candig",
+  "htsget-app": "http://candig.docker.internal:5080/genomics",
+  "katsu": "http://candig.docker.internal:5080/katsu"
 }
 ```
 </details>

--- a/docs/install-docker.md
+++ b/docs/install-docker.md
@@ -141,7 +141,7 @@ make build-all
 
 On some machines (MacOS), it may be necessary to add the following to /etc/hosts:
 ```
-::1	docker.localhost
+::1	candig.docker.internal
 ```
 
 In some other cases, it may be necessary to add your local (network) IP manually, if the build process complains that it could not find the right IP (`ERROR: Your internet adapter could not be found automatically.` or `ERROR: More than one IP has been detected.`). In this case, edit your .env file with:

--- a/etc/env/example.env
+++ b/etc/env/example.env
@@ -5,9 +5,9 @@
 CANDIG_MODULES=minio htsget-server chord-metadata candig-data-portal federation-service #drs-server wes-server logging monitoring
 CANDIG_AUTH_MODULES=keycloak tyk opa vault
 
-# options are [<ip_addr>, <url>, host.docker.internal, docker.localhost]
-CANDIG_DOMAIN=docker.localhost
-CANDIG_AUTH_DOMAIN=docker.localhost
+# options are [<ip_addr>, <url>, host.docker.internal, candig.docker.internal]
+CANDIG_DOMAIN=candig.docker.internal
+CANDIG_AUTH_DOMAIN=candig.docker.internal
 CANDIG_SITE_LOCATION=UHN
 CANDIG_DEBUG_MODE=1
 

--- a/etc/venv/requirements.txt
+++ b/etc/venv/requirements.txt
@@ -7,3 +7,5 @@ aiohttp
 requests
 pytest
 pytz
+candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v1.0.0
+minio==7.1.12

--- a/lib/candig-data-portal/docker-compose.yml
+++ b/lib/candig-data-portal/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - source: opa-service-token
         target: opa-service-token
     extra_hosts:
-        - "docker.localhost:${LOCAL_IP_ADDR}"
+        - "${CANDIG_DOMAIN}:${LOCAL_IP_ADDR}"
     environment:
       - REACT_APP_KATSU_API_SERVER=${CHORD_METADATA_PUBLIC_URL}
       - REACT_APP_HTSGET_SERVER=${HTSGET_PUBLIC_URL}

--- a/lib/chord-metadata/docker-compose.yml
+++ b/lib/chord-metadata/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     depends_on:
       - metadata-db
     extra_hosts:
-      - "docker.localhost:${LOCAL_IP_ADDR}"
+      - "${CANDIG_DOMAIN}:${LOCAL_IP_ADDR}"
     environment:
       - POSTGRES_DATABASE=metadata
       - POSTGRES_HOST=metadata-db
@@ -43,7 +43,7 @@ services:
       - POSTGRES_PASSWORD_FILE=/run/secrets/metadata_db_secret
       - POSTGRES_HOST_AUTH_METHOD=password
     extra_hosts:
-      - "docker.localhost:${LOCAL_IP_ADDR}"
+      - "${CANDIG_DOMAIN}:${LOCAL_IP_ADDR}"
     volumes:
       - postgres-data:/var/lib/postgresql/data
     secrets:

--- a/lib/federation-service/docker-compose.yml
+++ b/lib/federation-service/docker-compose.yml
@@ -18,5 +18,5 @@ services:
       - source: federation-services
         target: /app/federation_service/configs/services.json
     extra_hosts:
-        - "docker.localhost:${LOCAL_IP_ADDR}"
+        - "${CANDIG_DOMAIN}:${LOCAL_IP_ADDR}"
     entrypoint: ["uwsgi", "federation.ini", "--http", "0.0.0.0:4232"]

--- a/lib/htsget-server/docker-compose.yml
+++ b/lib/htsget-server/docker-compose.yml
@@ -34,5 +34,5 @@ services:
       DB_PATH: /data/files.db
       TESTENV_URL: ${HTSGET_PRIVATE_URL}
     extra_hosts:
-      - "docker.localhost:${LOCAL_IP_ADDR}"
+      - "${CANDIG_DOMAIN}:${LOCAL_IP_ADDR}"
     command: ["--host", "0.0.0.0", "--port", "3000"]

--- a/lib/keycloak/docker-compose.yml
+++ b/lib/keycloak/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     ports:
       - "${KEYCLOAK_CONTAINER_PORT}:8080"
     extra_hosts:
-      - "docker.localhost:${LOCAL_IP_ADDR}"
+      - "${CANDIG_DOMAIN}:${LOCAL_IP_ADDR}"
     volumes:
       - keycloak-data:/opt/jboss/keycloak/standalone
     environment:

--- a/lib/minio/docker-compose.yml
+++ b/lib/minio/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - source: minio-secret-key
         target: secret_key
     extra_hosts:
-        - "docker.localhost:${LOCAL_IP_ADDR}"
+        - "${CANDIG_DOMAIN}:${LOCAL_IP_ADDR}"
     command: ["server", "/data","--console-address", ":${MINIO_UI_PORT}"]
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]

--- a/lib/opa/docker-compose.yml
+++ b/lib/opa/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       IDP: "${KEYCLOAK_PUBLIC_URL}/auth/realms/${KEYCLOAK_REALM}"
       KATSU_URL: "${CHORD_METADATA_PUBLIC_URL}"
     extra_hosts:
-      - "docker.localhost:${LOCAL_IP_ADDR}"
+      - "${CANDIG_DOMAIN}:${LOCAL_IP_ADDR}"
 
   opa:
     image: openpolicyagent/opa:latest
@@ -53,4 +53,4 @@ services:
       timeout: 20s
       retries: 3
     extra_hosts:
-      - "docker.localhost:${LOCAL_IP_ADDR}"
+      - "${CANDIG_DOMAIN}:${LOCAL_IP_ADDR}"

--- a/lib/templates/docker-compose.yml
+++ b/lib/templates/docker-compose.yml
@@ -37,3 +37,5 @@ services:
       interval: 30s
       timeout: 20s
       retries: 3
+    extra_hosts:
+      - "${CANDIG_DOMAIN}:${LOCAL_IP_ADDR}"

--- a/lib/tyk/docker-compose.yml
+++ b/lib/tyk/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     depends_on:
       - tyk-redis
     extra_hosts:
-      - "docker.localhost:${LOCAL_IP_ADDR}"
+      - "${CANDIG_DOMAIN}:${LOCAL_IP_ADDR}"
     healthcheck:
       test: [ "CMD", "curl", "http://0.0.0.0:8080/hello" ]
       interval: 30s
@@ -31,7 +31,7 @@ services:
     ports:
       - "6379:6379"
     extra_hosts:
-      - "docker.localhost:${LOCAL_IP_ADDR}"
+      - "${CANDIG_DOMAIN}:${LOCAL_IP_ADDR}"
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 30s

--- a/lib/vault/docker-compose.yml
+++ b/lib/vault/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       timeout: 20s
       retries: 3
     extra_hosts:
-      - "docker.localhost:${LOCAL_IP_ADDR}"
+      - "${CANDIG_DOMAIN}:${LOCAL_IP_ADDR}"
 
   vault-runner:
     build:
@@ -41,5 +41,5 @@ services:
       - source: vault-s3-token
         target: vault-s3-token
     extra_hosts:
-      - "docker.localhost:${LOCAL_IP_ADDR}"
+      - "${CANDIG_DOMAIN}:${LOCAL_IP_ADDR}"
 

--- a/lib/wes-server/docker-compose.yml
+++ b/lib/wes-server/docker-compose.yml
@@ -46,6 +46,8 @@ services:
       #- --opt=extra=--batchSystem=Mesos
       #- --opt=extra=--mesosMaster=wes-server:5050
       #- --opt=extra=--beta-dependency-resolvers-configuration=dependency_resolver.yml
+    extra_hosts:
+      - "${CANDIG_DOMAIN}:${LOCAL_IP_ADDR}"
 
   wes-worker:
     image: ${DOCKER_REGISTRY}/wes-server:${WES_VERSION:-latest}
@@ -80,3 +82,5 @@ services:
       #- --image_providers=appc,docker
       #- --isolation=filesystem/linux,docker/runtime
       #- --resources=cpus:4
+    extra_hosts:
+      - "${CANDIG_DOMAIN}:${LOCAL_IP_ADDR}"

--- a/setup_hosts.sh
+++ b/setup_hosts.sh
@@ -6,7 +6,7 @@ if [[ ! -z ${LOCAL_IP_ADDR:-} ]]; then
     return
 fi
 
-# Replace docker.localhost entry in /etc/hosts
+# Find local IP address:
 if [ "$VENV_OS" == "linux" ]; then
     ip addr | grep -A 1 'wlp[0-9]\|eth[0-9]\|ens[0-9]' | grep -o "inet [0-9.]\+" | cut -d' ' -f2 > .hosts.tmp2
 else


### PR DESCRIPTION
https://candig.atlassian.net/browse/DIG-1133

I added the following to my /etc/hosts:
```
::1     candig.docker.internal
```

I did the following:
```
make clean-all
make bin-conda
make init-conda
make build-all
make test-integration
```
I had a few katsu tests fail, but I think that they were related to model changes I hadn't picked up:
```
FAILED etc/tests/test_integration.py::test_setup_katsu - assert ("code='unique'" in "[{}, {}, {}, {'date_of_death': [ErrorDetail(string='This field may not be null.', code='nul...
FAILED etc/tests/test_integration.py::test_katsu_users[CANDIG_SITE_ADMIN-SYNTHETIC-2-SYNTHETIC-1] - AssertionError: assert 'SYNTHETIC-2' in []
FAILED etc/tests/test_integration.py::test_katsu_users[CANDIG_NOT_ADMIN-SYNTHETIC-1-SYNTHETIC-2] - AssertionError: assert 'SYNTHETIC-1' in []
```
Otherwise, everything works as expected.