### PR TITLE
Fix an issue with pre-build-check which caused it to fail on certain MacOS systems

### DIFF
--- a/pre-build-check.sh
+++ b/pre-build-check.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 
-CANDIG_HOST=`getent hosts candig-dev`
+if command -v getent >/dev/null 2>&1; then
+    CANDIG_HOST=`getent hosts candig-dev`
+elif command -v dnscacheutil >/dev/null 2>&1; then
+    CANDIG_HOST=`dscacheutil -q host -a name candig-dev`
+fi
+
 if [ ! -z "$CANDIG_HOST" ]; then
     printf "Please disable the UHN VPN, as it causes errors with the build process"
     exit 1


### PR DESCRIPTION
Fixing an issue where the `make build-all` command fails on certain MacOS systems because getent doesn't work on them.