### PR TITLE
Diff the .env file, fix typo

### DIFF
--- a/pre-build-check.sh
+++ b/pre-build-check.sh
@@ -11,3 +11,19 @@ if [ ! -z "$CANDIG_HOST" ]; then
     exit 1
 fi
 
+DIFF_OUT=$(diff -I 'VENV_OS=.*' -I 'LOCAL_IP_ADDR=.*' -bwBE etc/env/example.env .env)
+if [ "$DIFF_OUT" == "" ]; then
+    echo "Your .env matches etc/env/example.env, continuing"
+else
+    echo "Your .env differs from etc/env/example.env:"
+    echo "$DIFF_OUT"
+    while true
+    do
+        read -r -p 'Do you want to continue? ' choice
+        case "$choice" in
+          n|N) exit 1;;
+          y|Y) exit 0;;
+          *) echo 'Response not valid';;
+        esac
+    done
+fi

--- a/pre-build-check.sh
+++ b/pre-build-check.sh
@@ -2,7 +2,7 @@
 
 if command -v getent >/dev/null 2>&1; then
     CANDIG_HOST=`getent hosts candig-dev`
-elif command -v dnscacheutil >/dev/null 2>&1; then
+elif command -v dscacheutil >/dev/null 2>&1; then
     CANDIG_HOST=`dscacheutil -q host -a name candig-dev`
 fi
 


### PR DESCRIPTION
There was a typo in the dscacheutil command line, so I fixed that.

While I was fixing that, I thought I'd add a more robust check for differences in .env: ignoring VENV_OS and LOCAL_IP_ADDR, which can be different from the example without being out of date, compare .env and etc/env/example.env. If there are differences, ask the user if they want to continue. If this script is run in the context of `make build-all`, it will continue on yes, and exit with error on no.