### PR TITLE
Add pre-build-checks to prevent the problems found during BCGSC test server deployment

### DIFF
--- a/pre-build-check.sh
+++ b/pre-build-check.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+# Check 1: UHN VPN is up
 if command -v getent >/dev/null 2>&1; then
     CANDIG_HOST=`getent hosts candig-dev`
 elif command -v dscacheutil >/dev/null 2>&1; then
@@ -11,6 +12,31 @@ if [ ! -z "$CANDIG_HOST" ]; then
     exit 1
 fi
 
+# Check 2: The value of CANDIG_DOMAIN can be reached
+if command -v getent >/dev/null 2>&1; then
+    TEST_DOMAIN=`getent hosts $CANDIG_DOMAIN`
+elif command -v dscacheutil >/dev/null 2>&1; then
+    TEST_DOMAIN=`dscacheutil -q host -a name $CANDIG_DOMAIN`
+fi
+
+if [ -z "$TEST_DOMAIN" ]; then
+    echo "Please ensure the value of \$CANDIG_DOMAIN in your .env file points to this machine"
+    echo "This should either be: 1) your local IP address, as assigned by your local network, or"
+    echo "2) a domain name that resolves to this IP address"
+    exit 1
+fi
+
+# Check 3: Submodules have been checked out
+TEST_SUBMODULES=`ls -l lib/opa/opa | wc -l`
+
+if [ "$TEST_SUBMODULES" -lt "2" ]; then
+    echo "lib/opa/opa was not found"
+    echo "Please ensure your submodules are checked out."
+    echo "The command to do so is git submodule update --init --recursive"
+    exit 1
+fi
+
+# Check 4: .env matches
 DIFF_OUT=$(diff -I 'VENV_OS=.*' -I 'LOCAL_IP_ADDR=.*' -bwB etc/env/example.env .env)
 if [ "$DIFF_OUT" == "" ]; then
     echo "Your .env matches etc/env/example.env, continuing"


### PR DESCRIPTION
This adds two more checks:
1. That the submodules have been checked out
2. That CANDIG_DOMAIN can be reached, whatever its value is