### PR TITLE
Change bash operators that may not work on all systems

### DIFF
--- a/etc/env/example.env
+++ b/etc/env/example.env
@@ -63,8 +63,8 @@ MINIO_SELF_CERT=0
 
 # docker volume options for minio-data
 #MINIO_VOLUME_OPT=--driver=local
-#MINIO_VOLUME_OPT+=--opt=type=ext4
-#MINIO_VOLUME_OPT+=--opt=device=/dev/sdb1
+#MINIO_VOLUME_OPT="${MINIO_VOLUME_OPT} --opt=type=ext4"
+#MINIO_VOLUME_OPT="${MINIO_VOLUME_OPT} --opt=device=/dev/sdb1"
 
 
 # htsget
@@ -85,20 +85,20 @@ WES_DEPENDENCY_RESOLVER=conda
 # pass runner specific options here
 #---
 # mesos
-WES_OPT=--opt=extra=--batchSystem=Mesos
-WES_OPT+=--opt=extra=--mesosMaster=toil-master:5050
-#WES_OPT+=--opt=extra=--singularity
-WES_OPT+=--opt=extra=--beta-dependency-resolver=/run/secrets/dependency_resolver.yml
-WES_OPT+=--opt=extra=--stats
-WES_OPT+=--opt=extra=--metrics
+WES_OPT="--opt=extra=--batchSystem=Mesos"
+WES_OPT="${WES_OPT} --opt=extra=--mesosMaster=toil-master:5050"
+#WES_OPT="${WES_OPT} --opt=extra=--singularity"
+WES_OPT="${WES_OPT} --opt=extra=--beta-dependency-resolver=/run/secrets/dependency_resolver.yml"
+WES_OPT="${WES_OPT} --opt=extra=--stats"
+WES_OPT="${WES_OPT} --opt=extra=--metrics"
 #---
 # pbs/torque
 #WES_OPT=--opt=extra=--batchSystem=Torque
-#WES_OPT+=--opt=extra=--disableCaching
-#WES_OPT+=--opt=extra=--no-container
-#WES_OPT+=--opt=extra=--beta-dependency-resolver=$HOME/.candig/etc/yml/hpf.yml
-#WES_OPT+=--opt=extra=--stats
-#WES_OPT+=--opt=extra=--metrics
+#WES_OPT="${WES_OPT} --opt=extra=--disableCaching"
+#WES_OPT="${WES_OPT} --opt=extra=--no-container"
+#WES_OPT="${WES_OPT} --opt=extra=--beta-dependency-resolver=$HOME/.candig/etc/yml/hpf.yml"
+#WES_OPT="${WES_OPT} --opt=extra=--stats"
+#WES_OPT="${WES_OPT} --opt=extra=--metrics"
 #---
 
 
@@ -262,5 +262,5 @@ CANDIG_DATA_PORTAL_PRIVATE_URL=http://candig-data-portal:3000
 
 
 # vault helper tool
-TOKEN_PATH = ${PWD}/Vault-Helper-Tool/token.txt
-PROGRESS_FILE = ${PWD}/tmp/progress.txt
+TOKEN_PATH=${PWD}/Vault-Helper-Tool/token.txt
+PROGRESS_FILE=${PWD}/tmp/progress.txt


### PR DESCRIPTION
- The concatenation operator += in the docker .env file doesn't seem to work on all systems, this removes them