### PR TITLE
DIG-1166: reorder vault setup

### DIFF
--- a/lib/vault/Dockerfile
+++ b/lib/vault/Dockerfile
@@ -17,13 +17,11 @@ RUN apk add --no-cache \
 WORKDIR /app
 
 # add the config file
-COPY ./tmp/vault-config.json /vault/config/vault-config.json
+COPY ./tmp/vault-config.json /app/config/vault-config.json
 
 # copy entrypoint
-COPY . /vault
-RUN mkdir /vault/data
-RUN chmod 777 /vault/data
+COPY . /app
 
 RUN touch initial_setup
 # run vault
-ENTRYPOINT ["bash", "/vault/entrypoint.sh"]
+ENTRYPOINT ["bash", "/app/entrypoint.sh"]

--- a/lib/vault/entrypoint.sh
+++ b/lib/vault/entrypoint.sh
@@ -4,6 +4,10 @@ set -Euo pipefail
 
 
 if [[ -f "initial_setup" ]]; then
+    cp -R /app/* /vault
+    mkdir /vault/data
+    chmod 777 /vault/data
+
     rm initial_setup
 else
     sleep 10
@@ -17,7 +21,7 @@ else
     KEY=$(head -n 4 /vault/config/keys.txt | tail -n 1)
     echo '{ "key": "'$KEY'" }' > payload.json
     curl --request POST --data @payload.json http://vault:8200/v1/sys/unseal
-    
+
 fi
 
 bash /vault/create_token.sh

--- a/lib/vault/vault_setup.sh
+++ b/lib/vault/vault_setup.sh
@@ -17,6 +17,11 @@ LOGFILE=$PWD/tmp/progress.txt
 # https://stackoverflow.com/questions/35703317/docker-exec-write-text-to-file-in-container
 # https://www.vaultproject.io/api-docs/secret/identity/entity#batch-delete-entities
 
+vault=$(docker ps -a --format "{{.Names}}" | grep vault_1 | awk '{print $1}')
+
+# if vault isn't started, start it:
+docker restart $vault
+
 echo ">> waiting for vault to start"
 docker ps --format "{{.Names}}" | grep vault_1
 while [ $? -ne 0 ]
@@ -29,7 +34,6 @@ sleep 5
 
 # gather keys and login token
 echo ">> gathering keys"
-vault=$(docker ps --format "{{.Names}}" | grep vault_1 | awk '{print $1}')
 stuff=$(docker exec $vault sh -c "vault operator init") # | head -7 | rev | cut -d " " -f1 | rev)
 echo "found stuff as ${stuff}"
 


### PR DESCRIPTION
It looks like the problem is that the Dockerfile writes things to /vault, which is an external volume that may not exist yet. I reordered the setup steps so that Dockerfile loads everything into /app, the local workdir, and then entrypoint copies it to /vault as part of the initial setup.

To test:
```
make clean-authx
make init-authx
make test-integration
```