### PR TITLE
DIG-1143: test SampleDrsObjects

### DIFF
--- a/etc/tests/test_integration.py
+++ b/etc/tests/test_integration.py
@@ -194,8 +194,27 @@ def test_htsget_add_sample_to_dataset():
     response = requests.post(f"{ENV['CANDIG_URL']}/genomics/ga4gh/drs/v1/datasets", headers=headers, json=payload)
     response = requests.get(f"{ENV['CANDIG_URL']}/genomics/ga4gh/drs/v1/datasets/SYNTHETIC-1", headers=headers)
     print(response.json())
-    assert "drs://localhost/multisample_1" in response.json()['drsobjects']
-    assert "drs://localhost/multisample_2" not in response.json()['drsobjects']
+    assert f"{TESTENV_URL}/multisample_1" in response.json()['drsobjects']
+    assert f"{TESTENV_URL}/multisample_2" not in response.json()['drsobjects']
+
+    # Delete dataset SYNTHETIC-2
+    response = requests.delete(f"{ENV['CANDIG_URL']}/genomics/ga4gh/drs/v1/datasets/SYNTHETIC-2", headers=headers)
+
+    # Add NA20787 and multisample_2 to dataset SYNTHETIC-2, which is only authorized for user2:
+    payload = {
+        "id": "SYNTHETIC-2",
+        "drsobjects": [
+            f"{TESTENV_URL}/NA20787",
+            f"{TESTENV_URL}/multisample_2"
+        ]
+    }
+
+    response = requests.post(f"{ENV['CANDIG_URL']}/genomics/ga4gh/drs/v1/datasets", headers=headers, json=payload)
+    response = requests.get(f"{ENV['CANDIG_URL']}/genomics/ga4gh/drs/v1/datasets/SYNTHETIC-2", headers=headers)
+    print(response.json())
+    assert f"{TESTENV_URL}/multisample_2" in response.json()['drsobjects']
+    assert f"{TESTENV_URL}/multisample_1" not in response.json()['drsobjects']
+
 
 
 ## Can we access the data when authorized to do so?

--- a/etc/tests/test_integration.py
+++ b/etc/tests/test_integration.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 import sys
 import pytest
 import requests
@@ -177,6 +178,7 @@ def test_htsget_add_sample_to_dataset():
         'Content-Type': 'application/json; charset=utf-8'
     }
 
+    TESTENV_URL = ENV["CANDIG_ENV"]["HTSGET_PUBLIC_URL"].replace("http://", "drs://").replace("https://", "drs://")
     # Delete dataset SYNTHETIC-1
     response = requests.delete(f"{ENV['CANDIG_URL']}/genomics/ga4gh/drs/v1/datasets/SYNTHETIC-1", headers=headers)
 
@@ -184,8 +186,8 @@ def test_htsget_add_sample_to_dataset():
     payload = {
         "id": "SYNTHETIC-1",
         "drsobjects": [
-            "drs://localhost/NA18537",
-            "drs://localhost/multisample_1"
+            f"{TESTENV_URL}/NA18537",
+            f"{TESTENV_URL}/multisample_1"
         ]
     }
 


### PR DESCRIPTION
Picked up a few fixes that I noticed about drs self-uris, added a test for creating a sampledrsobject. `make test-integration` should pass after you've picked up and rebuilt htsget from https://github.com/CanDIG/htsget_app/pull/261.