### PR TITLE
DIG-1172: Build validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,6 @@ CONDA = $(CONDA_INSTALL)/miniconda3/bin/conda
 CONDA_ENV_SETTINGS = $(CONDA_INSTALL)/miniconda3/etc/profile.d/conda.sh
 
 LOGFILE = tmp/progress.txt
-ERRORLOG = tmp/error.txt
 
 $(shell printf "Build started at `date '+%D %T'`.\n\n" >> $(ERRORLOG) $(ERRORLOG))
 

--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ build-%:
 	printf "\n\nErrors during build-$*: \n" >> $(ERRORLOG)
 	echo "    started build-$*" >> $(LOGFILE)
 	DOCKER_BUILDKIT=1 COMPOSE_DOCKER_CLI_BUILD=1 \
-	docker compose -f lib/candigv2/docker-compose.yml -f lib/$*/docker-compose.yml build $(BUILD_OPTS) --progress=plain 2> >(tee -a $(ERRORLOG))
+	docker compose -f lib/candigv2/docker-compose.yml -f lib/$*/docker-compose.yml build $(BUILD_OPTS) 1> >(tee -a >(grep -C 2 "[Ee]rror|[Ww]arning" >> $(ERRORLOG)) /dev/null) 2> >(tee -a $(ERRORLOG))
 	echo "    finished build-$*" >> $(LOGFILE)
 
 
@@ -241,10 +241,9 @@ compose:
 compose-%:
 	printf "\n\nErrors during compose-$*: \n" >> $(ERRORLOG)
 	echo "    started compose-$*" >> $(LOGFILE)
-	-source lib/$*/$*_preflight.sh 2> >(tee -a $(ERRORLOG))
-	source setup_hosts.sh; \
-	docker compose -f lib/candigv2/docker-compose.yml -f lib/$*/docker-compose.yml --compatibility up -d 2> >(tee -a $(ERRORLOG))
-	-source lib/$*/$*_setup.sh 2> >(tee -a $(ERRORLOG))
+	-source lib/$*/$*_preflight.sh 1> >(tee -a >(grep -C 2 "[Ee]rror|[Ww]arning" >> $(ERRORLOG)) /dev/null) 2> >(tee -a $(ERRORLOG))
+	docker compose -f lib/candigv2/docker-compose.yml -f lib/$*/docker-compose.yml --compatibility up -d 1> >(tee -a >(grep -C 2 "[Ee]rror|[Ww]arning" >> $(ERRORLOG)) /dev/null) 2> >(tee -a $(ERRORLOG))
+	-source lib/$*/$*_setup.sh 1> >(tee -a >(grep -C 2 "[Ee]rror|[Ww]arning" >> $(ERRORLOG)) /dev/null) 2> >(tee -a $(ERRORLOG))
 	echo "    finished compose-$*" >> $(LOGFILE)
 
 

--- a/Makefile
+++ b/Makefile
@@ -8,18 +8,20 @@ include Makefile.authx
 export $(shell sed 's/=.*//' $(env))
 
 SHELL = bash
+DIR = $(PWD)
+
 #>>>
-# option A : set CONDA_INSTALL to bin to install conda within the candigv2 repo
+# option A : set CONDA_INSTALL to $(DIR)/bin to install conda within the candigv2 repo
 #  and then use make bin-conda and make init-conda
 # option B: set CONDA_INSTALL to the location of an existing miniconda3 installation
 #  and then use make mkdir and make init-conda (no bin-conda, which will blow up an existing conda)
 # <<<
 
-CONDA_INSTALL = bin
+CONDA_INSTALL = $(DIR)/bin
 CONDA = $(CONDA_INSTALL)/miniconda3/bin/conda
 CONDA_ENV_SETTINGS = $(CONDA_INSTALL)/miniconda3/etc/profile.d/conda.sh
 
-LOGFILE = tmp/progress.txt
+LOGFILE = $(DIR)/tmp/progress.txt
 
 .PHONY: all
 all:
@@ -35,9 +37,10 @@ all:
 #<<<
 .PHONY: mkdir
 mkdir:
-	mkdir -p bin
-	mkdir -p tmp/{configs,data,secrets}
-	mkdir -p tmp/{keycloak,tyk,vault}
+	mkdir -p $(DIR)/bin
+	mkdir -p $(DIR)/tmp/{configs,data,secrets}
+	mkdir -p $(DIR)/tmp/{keycloak,tyk,vault}
+	mkdir -p ${DIR}/tmp/federation
 
 
 #>>>
@@ -57,27 +60,27 @@ bin-all: bin-conda
 bin-conda: mkdir
 	echo "    started bin-conda" >> $(LOGFILE)
 ifeq ($(VENV_OS), linux)
-	curl -Lo bin/miniconda_install.sh \
+	curl -Lo $(DIR)/bin/miniconda_install.sh \
 		https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
-	bash bin/miniconda_install.sh -f -b -u -p $(CONDA_INSTALL)/miniconda3
+	bash $(DIR)/bin/miniconda_install.sh -f -b -u -p $(CONDA_INSTALL)/miniconda3
 	# init is needed to create bash aliases for conda but it won't work
 	# until you source the script that ships with conda
 	source $(CONDA_ENV_SETTINGS) && $(CONDA) init
 	echo "    finished bin-conda" >> $(LOGFILE)
 endif
 ifeq ($(VENV_OS), darwin)
-	curl -Lo bin/miniconda_install.sh \
+	curl -Lo $(DIR)/bin/miniconda_install.sh \
 		https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
-	bash bin/miniconda_install.sh -f -b -u -p $(CONDA_INSTALL)/miniconda3
+	bash $(DIR)/bin/miniconda_install.sh -f -b -u -p $(CONDA_INSTALL)/miniconda3
 	# init is needed to create bash aliases for conda but it won't work
 	# until you source the script that ships with conda
 	source $(CONDA_ENV_SETTINGS) && $(CONDA) init
 	echo "    finished bin-conda" >> $(LOGFILE)
 endif
 ifeq ($(VENV_OS), arm64mac)
-	curl -Lo bin/miniconda_install.sh \
+	curl -Lo $(DIR)/bin/miniconda_install.sh \
 		https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-arm64.sh
-	bash bin/miniconda_install.sh -f -b -u -p $(CONDA_INSTALL)/miniconda3
+	bash $(DIR)/bin/miniconda_install.sh -f -b -u -p $(CONDA_INSTALL)/miniconda3
 	# init is needed to create bash aliases for conda but it won't work
 	# until you source the script that ships with conda
 	source $(CONDA_ENV_SETTINGS) && $(CONDA) init zsh
@@ -98,6 +101,8 @@ build-all:
 	$(MAKE) build-images
 	$(MAKE) compose
 	$(MAKE) init-authx
+	
+	./post_build.sh
 
 
 #>>>
@@ -123,7 +128,7 @@ build-images: #toil-docker
 build-%:
 	echo "    started build-$*" >> $(LOGFILE)
 	DOCKER_BUILDKIT=1 COMPOSE_DOCKER_CLI_BUILD=1 \
-	docker compose -f lib/candigv2/docker-compose.yml -f lib/$*/docker-compose.yml build $(BUILD_OPTS)
+	docker compose -f $(DIR)/lib/candigv2/docker-compose.yml -f $(DIR)/lib/$*/docker-compose.yml build $(BUILD_OPTS)
 	echo "    finished build-$*" >> $(LOGFILE)
 
 
@@ -146,7 +151,7 @@ clean-all: clean-authx clean-compose clean-containers clean-secrets \
 #<<<
 .PHONY: clean-bin
 clean-bin:
-	rm -rf bin
+	rm -rf $(DIR)/bin
 
 
 #>>>
@@ -156,9 +161,9 @@ clean-bin:
 #<<<
 .PHONY: clean-compose
 clean-compose:
-	source setup_hosts.sh; \
+	source ${PWD}/setup_hosts.sh; \
 	$(foreach MODULE, $(CANDIG_MODULES), \
-		docker compose -f lib/candigv2/docker-compose.yml -f lib/$(MODULE)/docker-compose.yml down || true;)
+		docker compose -f $(DIR)/lib/candigv2/docker-compose.yml -f $(DIR)/lib/$(MODULE)/docker-compose.yml down || true;)
 
 
 #>>>
@@ -201,7 +206,7 @@ clean-images:
 .PHONY: clean-secrets
 clean-secrets:
 	-docker secret rm `docker secret ls -q --filter label=candigv2`
-	rm -rf tmp/secrets
+	rm -rf $(DIR)/tmp/secrets
 
 
 #>>>
@@ -213,7 +218,7 @@ clean-secrets:
 clean-volumes:
 	-docker volume rm `docker volume ls -q --filter label=candigv2`
 	-docker volume rm `docker volume ls -q --filter dangling=true`
-#rm -rf tmp/data
+#rm -rf $(DIR)/tmp/data
 
 
 #>>>
@@ -223,7 +228,7 @@ clean-volumes:
 #<<<
 .PHONY: compose
 compose:
-	source setup_hosts.sh; \
+	source ${PWD}/setup_hosts.sh; \
 	$(foreach MODULE, $(CANDIG_MODULES), $(MAKE) compose-$(MODULE);)
 
 
@@ -235,10 +240,10 @@ compose:
 #<<<
 compose-%:
 	echo "    started compose-$*" >> $(LOGFILE)
-	-source lib/$*/$*_preflight.sh
-	source setup_hosts.sh; \
-	docker compose -f lib/candigv2/docker-compose.yml -f lib/$*/docker-compose.yml --compatibility up -d
-	-source lib/$*/$*_setup.sh
+	-source $(DIR)/lib/$*/$*_preflight.sh
+	source ${PWD}/setup_hosts.sh; \
+	docker compose -f $(DIR)/lib/candigv2/docker-compose.yml -f $(DIR)/lib/$*/docker-compose.yml --compatibility up -d
+	-source $(DIR)/lib/$*/$*_setup.sh
 	echo "    finished compose-$*" >> $(LOGFILE)
 
 
@@ -271,17 +276,17 @@ docker-push:
 #<<<
 .PHONY: docker-secrets
 docker-secrets: mkdir minio-secrets
-	@echo admin > tmp/secrets/metadata-db-user
+	@echo admin > $(DIR)/tmp/secrets/metadata-db-user
 	$(MAKE) secret-metadata-app-secret
 	$(MAKE) secret-metadata-db-secret
 
-	@echo admin > tmp/secrets/keycloak-admin-user
+	@echo admin > $(DIR)/tmp/secrets/keycloak-admin-user
 	$(MAKE) secret-keycloak-admin-password
 
-	@echo user1 > tmp/secrets/keycloak-test-user
+	@echo user1 > $(DIR)/tmp/secrets/keycloak-test-user
 	$(MAKE) secret-keycloak-test-user-password
 
-	@echo user2 > tmp/secrets/keycloak-test-user2
+	@echo user2 > $(DIR)/tmp/secrets/keycloak-test-user2
 	$(MAKE) secret-keycloak-test-user2-password
 
 	$(MAKE) secret-tyk-secret-key
@@ -329,11 +334,11 @@ init-conda:
 
 	source $(CONDA_ENV_SETTINGS) \
 		&& conda activate $(VENV_NAME) \
-		&& pip install -U -r etc/venv/requirements.txt
+		&& pip install -U -r $(DIR)/etc/venv/requirements.txt
 
-#@echo "Load local conda: source bin/miniconda3/etc/profile.d/conda.sh"
+#@echo "Load local conda: source $(DIR)/bin/miniconda3/etc/profile.d/conda.sh"
 #@echo "Activate conda env: conda activate $(VENV_NAME)"
-#@echo "Install requirements: pip install -U -r etc/venv/requirements.txt"
+#@echo "Install requirements: pip install -U -r $(DIR)/etc/venv/requirements.txt"
 	echo "    finished init-conda" >> $(LOGFILE)
 
 
@@ -352,11 +357,11 @@ init-docker: docker-volumes docker-secrets
 
 #<<<
 minio-secrets:
-	@echo admin > tmp/secrets/minio-access-key
+	@echo admin > $(DIR)/tmp/secrets/minio-access-key
 	$(MAKE) secret-minio-secret-key
-	@echo '[default]' > tmp/secrets/aws-credentials
-	@echo "aws_access_key_id=`cat tmp/secrets/minio-access-key`" >> tmp/secrets/aws-credentials
-	@echo "aws_secret_access_key=`cat tmp/secrets/minio-secret-key`" >> tmp/secrets/aws-credentials
+	@echo '[default]' > $(DIR)/tmp/secrets/aws-credentials
+	@echo "aws_access_key_id=`cat tmp/secrets/minio-access-key`" >> $(DIR)/tmp/secrets/aws-credentials
+	@echo "aws_secret_access_key=`cat tmp/secrets/minio-secret-key`" >> $(DIR)/tmp/secrets/aws-credentials
 
 
 #>>>
@@ -366,7 +371,7 @@ minio-secrets:
 
 #<<<
 pull-%:
-		docker compose -f lib/candigv2/docker-compose.yml -f lib/$*/docker-compose.yml pull
+		docker compose -f $(DIR)/lib/candigv2/docker-compose.yml -f $(DIR)/lib/$*/docker-compose.yml pull
 
 
 #>>>
@@ -376,7 +381,7 @@ pull-%:
 
 #<<<
 push-%:
-		docker compose -f lib/candigv2/docker-compose.yml -f lib/$*/docker-compose.yml push
+		docker compose -f $(DIR)/lib/candigv2/docker-compose.yml -f $(DIR)/lib/$*/docker-compose.yml push
 
 
 #>>>
@@ -386,7 +391,7 @@ push-%:
 #<<<
 secret-%:
 	@dd if=/dev/urandom bs=1 count=16 2>/dev/null \
-		| base64 | tr -d '\n\r+' | sed s/[^A-Za-z0-9]//g > tmp/secrets/$*
+		| base64 | tr -d '\n\r+' | sed s/[^A-Za-z0-9]//g > $(DIR)/tmp/secrets/$*
 
 
 #>>>
@@ -398,7 +403,7 @@ secret-%:
 toil-docker:
 	echo "    started toil-docker" >> $(LOGFILE)
 	VIRTUAL_ENV=1 DOCKER_BUILDKIT=1 COMPOSE_DOCKER_CLI_BUILD=1 TOIL_DOCKER_REGISTRY=$(DOCKER_REGISTRY) \
-	$(MAKE) -C lib/toil/toil-docker docker
+	$(MAKE) -C $(DIR)/lib/toil/toil-docker docker
 	$(foreach MODULE,$(TOIL_MODULES), \
 		docker tag $(DOCKER_REGISTRY)/$(MODULE):$(TOIL_VERSION)-$(TOIL_BUILD_HASH) \
 		$(DOCKER_REGISTRY)/$(MODULE):$(TOIL_VERSION);)

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,8 @@ CONDA_ENV_SETTINGS = $(CONDA_INSTALL)/miniconda3/etc/profile.d/conda.sh
 LOGFILE = tmp/progress.txt
 ERRORLOG = tmp/error.txt
 
+$(shell > $(ERRORLOG))
+
 .PHONY: all
 all:
 	@echo "CanDIGv2 Makefile Deployment"
@@ -127,6 +129,7 @@ build-images: #toil-docker
 build-%:
 	printf "\n\nErrors during build-$*: \n" >> $(ERRORLOG)
 	echo "    started build-$*" >> $(LOGFILE)
+	source setup_hosts.sh; \
 	DOCKER_BUILDKIT=1 COMPOSE_DOCKER_CLI_BUILD=1 \
 	docker compose -f lib/candigv2/docker-compose.yml -f lib/$*/docker-compose.yml build $(BUILD_OPTS) 1> >(tee -a >(grep -C 2 "[Ee]rror|[Ww]arning" >> $(ERRORLOG)) /dev/null) 2> >(tee -a $(ERRORLOG))
 	echo "    finished build-$*" >> $(LOGFILE)
@@ -242,6 +245,7 @@ compose-%:
 	printf "\n\nErrors during compose-$*: \n" >> $(ERRORLOG)
 	echo "    started compose-$*" >> $(LOGFILE)
 	-source lib/$*/$*_preflight.sh 1> >(tee -a >(grep -C 2 "[Ee]rror|[Ww]arning" >> $(ERRORLOG)) /dev/null) 2> >(tee -a $(ERRORLOG))
+	source setup_hosts.sh; \
 	docker compose -f lib/candigv2/docker-compose.yml -f lib/$*/docker-compose.yml --compatibility up -d 1> >(tee -a >(grep -C 2 "[Ee]rror|[Ww]arning" >> $(ERRORLOG)) /dev/null) 2> >(tee -a $(ERRORLOG))
 	-source lib/$*/$*_setup.sh 1> >(tee -a >(grep -C 2 "[Ee]rror|[Ww]arning" >> $(ERRORLOG)) /dev/null) 2> >(tee -a $(ERRORLOG))
 	echo "    finished compose-$*" >> $(LOGFILE)

--- a/Makefile
+++ b/Makefile
@@ -8,20 +8,18 @@ include Makefile.authx
 export $(shell sed 's/=.*//' $(env))
 
 SHELL = bash
-DIR = $(PWD)
-
 #>>>
-# option A : set CONDA_INSTALL to $(DIR)/bin to install conda within the candigv2 repo
+# option A : set CONDA_INSTALL to bin to install conda within the candigv2 repo
 #  and then use make bin-conda and make init-conda
 # option B: set CONDA_INSTALL to the location of an existing miniconda3 installation
 #  and then use make mkdir and make init-conda (no bin-conda, which will blow up an existing conda)
 # <<<
 
-CONDA_INSTALL = $(DIR)/bin
+CONDA_INSTALL = bin
 CONDA = $(CONDA_INSTALL)/miniconda3/bin/conda
 CONDA_ENV_SETTINGS = $(CONDA_INSTALL)/miniconda3/etc/profile.d/conda.sh
 
-LOGFILE = $(DIR)/tmp/progress.txt
+LOGFILE = tmp/progress.txt
 
 .PHONY: all
 all:
@@ -37,10 +35,9 @@ all:
 #<<<
 .PHONY: mkdir
 mkdir:
-	mkdir -p $(DIR)/bin
-	mkdir -p $(DIR)/tmp/{configs,data,secrets}
-	mkdir -p $(DIR)/tmp/{keycloak,tyk,vault}
-	mkdir -p ${DIR}/tmp/federation
+	mkdir -p bin
+	mkdir -p tmp/{configs,data,secrets}
+	mkdir -p tmp/{keycloak,tyk,vault}
 
 
 #>>>
@@ -60,27 +57,27 @@ bin-all: bin-conda
 bin-conda: mkdir
 	echo "    started bin-conda" >> $(LOGFILE)
 ifeq ($(VENV_OS), linux)
-	curl -Lo $(DIR)/bin/miniconda_install.sh \
+	curl -Lo bin/miniconda_install.sh \
 		https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
-	bash $(DIR)/bin/miniconda_install.sh -f -b -u -p $(CONDA_INSTALL)/miniconda3
+	bash bin/miniconda_install.sh -f -b -u -p $(CONDA_INSTALL)/miniconda3
 	# init is needed to create bash aliases for conda but it won't work
 	# until you source the script that ships with conda
 	source $(CONDA_ENV_SETTINGS) && $(CONDA) init
 	echo "    finished bin-conda" >> $(LOGFILE)
 endif
 ifeq ($(VENV_OS), darwin)
-	curl -Lo $(DIR)/bin/miniconda_install.sh \
+	curl -Lo bin/miniconda_install.sh \
 		https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
-	bash $(DIR)/bin/miniconda_install.sh -f -b -u -p $(CONDA_INSTALL)/miniconda3
+	bash bin/miniconda_install.sh -f -b -u -p $(CONDA_INSTALL)/miniconda3
 	# init is needed to create bash aliases for conda but it won't work
 	# until you source the script that ships with conda
 	source $(CONDA_ENV_SETTINGS) && $(CONDA) init
 	echo "    finished bin-conda" >> $(LOGFILE)
 endif
 ifeq ($(VENV_OS), arm64mac)
-	curl -Lo $(DIR)/bin/miniconda_install.sh \
+	curl -Lo bin/miniconda_install.sh \
 		https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-arm64.sh
-	bash $(DIR)/bin/miniconda_install.sh -f -b -u -p $(CONDA_INSTALL)/miniconda3
+	bash bin/miniconda_install.sh -f -b -u -p $(CONDA_INSTALL)/miniconda3
 	# init is needed to create bash aliases for conda but it won't work
 	# until you source the script that ships with conda
 	source $(CONDA_ENV_SETTINGS) && $(CONDA) init zsh
@@ -128,7 +125,7 @@ build-images: #toil-docker
 build-%:
 	echo "    started build-$*" >> $(LOGFILE)
 	DOCKER_BUILDKIT=1 COMPOSE_DOCKER_CLI_BUILD=1 \
-	docker compose -f $(DIR)/lib/candigv2/docker-compose.yml -f $(DIR)/lib/$*/docker-compose.yml build $(BUILD_OPTS)
+	docker compose -f lib/candigv2/docker-compose.yml -f lib/$*/docker-compose.yml build $(BUILD_OPTS)
 	echo "    finished build-$*" >> $(LOGFILE)
 
 
@@ -151,7 +148,7 @@ clean-all: clean-authx clean-compose clean-containers clean-secrets \
 #<<<
 .PHONY: clean-bin
 clean-bin:
-	rm -rf $(DIR)/bin
+	rm -rf bin
 
 
 #>>>
@@ -161,9 +158,9 @@ clean-bin:
 #<<<
 .PHONY: clean-compose
 clean-compose:
-	source ${PWD}/setup_hosts.sh; \
+	source setup_hosts.sh; \
 	$(foreach MODULE, $(CANDIG_MODULES), \
-		docker compose -f $(DIR)/lib/candigv2/docker-compose.yml -f $(DIR)/lib/$(MODULE)/docker-compose.yml down || true;)
+		docker compose -f lib/candigv2/docker-compose.yml -f lib/$(MODULE)/docker-compose.yml down || true;)
 
 
 #>>>
@@ -206,7 +203,7 @@ clean-images:
 .PHONY: clean-secrets
 clean-secrets:
 	-docker secret rm `docker secret ls -q --filter label=candigv2`
-	rm -rf $(DIR)/tmp/secrets
+	rm -rf tmp/secrets
 
 
 #>>>
@@ -218,7 +215,7 @@ clean-secrets:
 clean-volumes:
 	-docker volume rm `docker volume ls -q --filter label=candigv2`
 	-docker volume rm `docker volume ls -q --filter dangling=true`
-#rm -rf $(DIR)/tmp/data
+#rm -rf tmp/data
 
 
 #>>>
@@ -228,7 +225,7 @@ clean-volumes:
 #<<<
 .PHONY: compose
 compose:
-	source ${PWD}/setup_hosts.sh; \
+	source setup_hosts.sh; \
 	$(foreach MODULE, $(CANDIG_MODULES), $(MAKE) compose-$(MODULE);)
 
 
@@ -240,10 +237,10 @@ compose:
 #<<<
 compose-%:
 	echo "    started compose-$*" >> $(LOGFILE)
-	-source $(DIR)/lib/$*/$*_preflight.sh
-	source ${PWD}/setup_hosts.sh; \
-	docker compose -f $(DIR)/lib/candigv2/docker-compose.yml -f $(DIR)/lib/$*/docker-compose.yml --compatibility up -d
-	-source $(DIR)/lib/$*/$*_setup.sh
+	-source lib/$*/$*_preflight.sh
+	source setup_hosts.sh; \
+	docker compose -f lib/candigv2/docker-compose.yml -f lib/$*/docker-compose.yml --compatibility up -d
+	-source lib/$*/$*_setup.sh
 	echo "    finished compose-$*" >> $(LOGFILE)
 
 
@@ -276,17 +273,17 @@ docker-push:
 #<<<
 .PHONY: docker-secrets
 docker-secrets: mkdir minio-secrets
-	@echo admin > $(DIR)/tmp/secrets/metadata-db-user
+	@echo admin > tmp/secrets/metadata-db-user
 	$(MAKE) secret-metadata-app-secret
 	$(MAKE) secret-metadata-db-secret
 
-	@echo admin > $(DIR)/tmp/secrets/keycloak-admin-user
+	@echo admin > tmp/secrets/keycloak-admin-user
 	$(MAKE) secret-keycloak-admin-password
 
-	@echo user1 > $(DIR)/tmp/secrets/keycloak-test-user
+	@echo user1 > tmp/secrets/keycloak-test-user
 	$(MAKE) secret-keycloak-test-user-password
 
-	@echo user2 > $(DIR)/tmp/secrets/keycloak-test-user2
+	@echo user2 > tmp/secrets/keycloak-test-user2
 	$(MAKE) secret-keycloak-test-user2-password
 
 	$(MAKE) secret-tyk-secret-key
@@ -334,11 +331,11 @@ init-conda:
 
 	source $(CONDA_ENV_SETTINGS) \
 		&& conda activate $(VENV_NAME) \
-		&& pip install -U -r $(DIR)/etc/venv/requirements.txt
+		&& pip install -U -r etc/venv/requirements.txt
 
-#@echo "Load local conda: source $(DIR)/bin/miniconda3/etc/profile.d/conda.sh"
+#@echo "Load local conda: source bin/miniconda3/etc/profile.d/conda.sh"
 #@echo "Activate conda env: conda activate $(VENV_NAME)"
-#@echo "Install requirements: pip install -U -r $(DIR)/etc/venv/requirements.txt"
+#@echo "Install requirements: pip install -U -r etc/venv/requirements.txt"
 	echo "    finished init-conda" >> $(LOGFILE)
 
 
@@ -357,11 +354,11 @@ init-docker: docker-volumes docker-secrets
 
 #<<<
 minio-secrets:
-	@echo admin > $(DIR)/tmp/secrets/minio-access-key
+	@echo admin > tmp/secrets/minio-access-key
 	$(MAKE) secret-minio-secret-key
-	@echo '[default]' > $(DIR)/tmp/secrets/aws-credentials
-	@echo "aws_access_key_id=`cat tmp/secrets/minio-access-key`" >> $(DIR)/tmp/secrets/aws-credentials
-	@echo "aws_secret_access_key=`cat tmp/secrets/minio-secret-key`" >> $(DIR)/tmp/secrets/aws-credentials
+	@echo '[default]' > tmp/secrets/aws-credentials
+	@echo "aws_access_key_id=`cat tmp/secrets/minio-access-key`" >> tmp/secrets/aws-credentials
+	@echo "aws_secret_access_key=`cat tmp/secrets/minio-secret-key`" >> tmp/secrets/aws-credentials
 
 
 #>>>
@@ -371,7 +368,7 @@ minio-secrets:
 
 #<<<
 pull-%:
-		docker compose -f $(DIR)/lib/candigv2/docker-compose.yml -f $(DIR)/lib/$*/docker-compose.yml pull
+		docker compose -f lib/candigv2/docker-compose.yml -f lib/$*/docker-compose.yml pull
 
 
 #>>>
@@ -381,7 +378,7 @@ pull-%:
 
 #<<<
 push-%:
-		docker compose -f $(DIR)/lib/candigv2/docker-compose.yml -f $(DIR)/lib/$*/docker-compose.yml push
+		docker compose -f lib/candigv2/docker-compose.yml -f lib/$*/docker-compose.yml push
 
 
 #>>>
@@ -391,7 +388,7 @@ push-%:
 #<<<
 secret-%:
 	@dd if=/dev/urandom bs=1 count=16 2>/dev/null \
-		| base64 | tr -d '\n\r+' | sed s/[^A-Za-z0-9]//g > $(DIR)/tmp/secrets/$*
+		| base64 | tr -d '\n\r+' | sed s/[^A-Za-z0-9]//g > tmp/secrets/$*
 
 
 #>>>
@@ -403,7 +400,7 @@ secret-%:
 toil-docker:
 	echo "    started toil-docker" >> $(LOGFILE)
 	VIRTUAL_ENV=1 DOCKER_BUILDKIT=1 COMPOSE_DOCKER_CLI_BUILD=1 TOIL_DOCKER_REGISTRY=$(DOCKER_REGISTRY) \
-	$(MAKE) -C $(DIR)/lib/toil/toil-docker docker
+	$(MAKE) -C lib/toil/toil-docker docker
 	$(foreach MODULE,$(TOIL_MODULES), \
 		docker tag $(DOCKER_REGISTRY)/$(MODULE):$(TOIL_VERSION)-$(TOIL_BUILD_HASH) \
 		$(DOCKER_REGISTRY)/$(MODULE):$(TOIL_VERSION);)

--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,6 @@ LOGFILE = tmp/progress.txt
 
 $(shell printf "Build started at `date '+%D %T'`.\n\n" >> $(ERRORLOG) $(ERRORLOG))
 
-export BUILDKIT_PROGRESS := tty
-
 .PHONY: all
 all:
 	@echo "CanDIGv2 Makefile Deployment"
@@ -127,7 +125,7 @@ build-images: #toil-docker
 
 #<<<
 build-%:
-	printf "\n\nErrors during build-$*: \n" >> $(ERRORLOG)
+	printf "\nOutput of build-$*: \n" >> $(ERRORLOG)
 	echo "    started build-$*" >> $(LOGFILE)
 	source setup_hosts.sh; \
 	DOCKER_BUILDKIT=1 COMPOSE_DOCKER_CLI_BUILD=1 \
@@ -248,7 +246,7 @@ compose:
 
 #<<<
 compose-%:
-	printf "\n\nErrors during compose-$*: \n" >> $(ERRORLOG)
+	printf "\nOutput of compose-$*: \n" >> $(ERRORLOG)
 	echo "    started compose-$*" >> $(LOGFILE)
 	-source lib/$*/$*_preflight.sh 2>&1 | tee -a $(ERRORLOG)
 	source setup_hosts.sh; \

--- a/etc/env/example.env
+++ b/etc/env/example.env
@@ -279,3 +279,6 @@ CANDIG_DATA_PORTAL_PRIVATE_URL=http://candig-data-portal:3000
 # vault helper tool
 TOKEN_PATH = ${PWD}/Vault-Helper-Tool/token.txt
 PROGRESS_FILE = ${PWD}/tmp/progress.txt
+
+# error logging
+ERRORLOG=tmp/error.txt

--- a/post_build.sh
+++ b/post_build.sh
@@ -65,11 +65,17 @@ for MODULE in $ALL_MODULES; do
 	SERVICE_COUNT=$((SERVICE_COUNT + MODULE_SERVICES))
 done
 
+RUNNING_MODULES=$(docker ps --format "{{.Names}}")
+
 if [ $(docker ps -q | wc -l) == $SERVICE_COUNT ]
 then
-	echo -e "${GREEN}Number of expected CanDIG services matches number of containers running!${DEFAULT}"
+	for MODULE in $ALL_MODULES; do
+		printf "\n\n${BLUE}Error logs for ${MODULE}:\n--------------------\n${DEFAULT}"
+		print_module_logs $MODULE
+		printf "${BLUE}--------------------\n${DEFAULT}"
+	done
+	echo -e "${GREEN}Number of expected CanDIG services matches number of containers running!${DEFAULT} Potentially useful error log segments listed above for debugging."
 else
-	RUNNING_MODULES=$(docker ps --format "{{.Names}}")
 	for MODULE in $ALL_MODULES; do
 		printf "\n\n${RED}Error logs for ${MODULE}:\n--------------------\n${DEFAULT}"
 		print_module_logs $MODULE

--- a/post_build.sh
+++ b/post_build.sh
@@ -9,7 +9,7 @@ declare -A MODULE_COUNTS
 # Note: Logging, drs-server and wes-server are not currently built by
 # the Makefile. Their values will need to be changed when this is no
 # longer the case.
-MODULE_COUNTS=( ["candig-data-portal"]=1 ["federation-service"]=1 ["htsget"]=1
+MODULE_COUNTS=( ["candig-data-portal"]=1 ["federation"]=1 ["htsget"]=1
 				["katsu"]=2 ["keycloak"]=1 ["logging"]=3 ["minio"]=1 ["monitoring"]=5
 				["opa"]=2 ["toil"]=2 ["tyk"]=2 ["vault"]=2 ["wes-server"]=1 ["drs-server"]=0 )
 				
@@ -30,8 +30,8 @@ done
 
 if [ $(docker ps -q | wc -l) == $SERVICE_COUNT ]
 then
-	echo -e "${GREEN}Number of expected services matches number of containers running!${DEFAULT}"
+	echo -e "${GREEN}Number of expected CanDIG services matches number of containers running!${DEFAULT}"
 else
-	echo -e "${RED}WARNING: ${YELLOW}The number of containers running does not match the number of expected services.\nRunning: ${BLUE}$(docker ps -q | wc -l) ${YELLOW}Expected: ${BLUE}${SERVICE_COUNT}
+	echo -e "${RED}WARNING: ${YELLOW}The number of CanDIG containers running does not match the number of expected services.\nRunning: ${BLUE}$(docker ps -q | wc -l) ${YELLOW}Expected: ${BLUE}${SERVICE_COUNT}
 ${DEFAULT}Check your build/docker logs."
 fi

--- a/post_build.sh
+++ b/post_build.sh
@@ -1,0 +1,37 @@
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+GREEN='\033[0;32m'
+DEFAULT='\033[0m'
+
+declare -A MODULE_COUNTS
+
+# Note: Logging, drs-server and wes-server are not currently built by
+# the Makefile. Their values will need to be changed when this is no
+# longer the case.
+MODULE_COUNTS=( ["candig-data-portal"]=1 ["federation-service"]=1 ["htsget"]=1
+				["katsu"]=2 ["keycloak"]=1 ["logging"]=3 ["minio"]=1 ["monitoring"]=5
+				["opa"]=2 ["toil"]=2 ["tyk"]=2 ["vault"]=2 ["wes-server"]=1 ["drs-server"]=0 )
+				
+SERVICE_COUNT=0
+
+MODULES=$(cat .env | grep CANDIG_MODULES | cut -c 16- | cut -d '#' -f 1)
+	
+for MODULE in $MODULES; do
+	MODULE_SERVICES=${MODULE_COUNTS[$MODULE]}
+	SERVICE_COUNT=$((SERVICE_COUNT + MODULE_SERVICES))
+done
+
+MODULES_AUTH=$(cat .env | grep CANDIG_AUTH_MODULES | cut -c 21- | cut -d '#' -f 1)
+for MODULE in $MODULES_AUTH; do
+	MODULE_SERVICES=${MODULE_COUNTS[$MODULE]}
+	SERVICE_COUNT=$((SERVICE_COUNT + MODULE_SERVICES))
+done
+
+if [ $(docker ps -q | wc -l) == $SERVICE_COUNT ]
+then
+	echo -e "${GREEN}Number of expected services matches number of containers running!${DEFAULT}"
+else
+	echo -e "${RED}WARNING: ${YELLOW}The number of containers running does not match the number of expected services.\nRunning: ${BLUE}$(docker ps -q | wc -l) ${YELLOW}Expected: ${BLUE}${SERVICE_COUNT}
+${DEFAULT}Check your build/docker logs."
+fi

--- a/post_build.sh
+++ b/post_build.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 
 # This script is meant to be run after make build-all, and checks whether
-# the number of running docker containers matches the number of containers
-# that should be running based on enabled services specified in .env.
+# the number of currently running docker containers matches the number of 
+# containers that should be running based on enabled services specified in .env. 
+# Also prints out all relevant logs from the error logging file (i.e., all lines 
+# that contain the phrases 'error' or 'warn').
 
 ERRORLOG="tmp/error.txt"
 

--- a/post_build.sh
+++ b/post_build.sh
@@ -6,7 +6,7 @@
 # Also prints out all relevant logs from the error logging file (i.e., all lines 
 # that contain the phrases 'error' or 'warn').
 
-ERRORLOG="tmp/error.txt"
+source <(grep --color=never "ERRORLOG" .env)
 
 RED='\033[0;31m'
 YELLOW='\033[1;33m'
@@ -45,7 +45,6 @@ function print_module_logs() {
 		done < <(tail -n "+$((COMPOSE_LINE+1))" $ERRORLOG)
 	fi
 }
-
 
 declare -A MODULE_COUNTS
 

--- a/post_build.sh
+++ b/post_build.sh
@@ -20,7 +20,7 @@ function print_module_logs() {
 	if [[ $BUILD_LINE != "" ]]; then
 		LNO=$BUILD_LINE
 		while read -r LINE; do
-			if [[ $LINE == "Errors during build-"* || $LINE == "Errors during compose-"* ]]; then
+			if [[ $LINE == "Output of build-"* || $LINE == "Output of compose-"* ]]; then
 				break
 			else
 				if [[ ${LINE,,} =~ .*(error|warn).* ]]; then
@@ -34,7 +34,7 @@ function print_module_logs() {
 	if [[ $COMPOSE_LINE != "" ]]; then
 		LNO=$COMPOSE_LINE
 		while read -r LINE; do
-			if [[ $LINE == "Errors during build-"* || $LINE == "Errors during compose-"* ]]; then
+			if [[ $LINE == "Output of build-"* || $LINE == "Output of compose-"* ]]; then
 				break
 			else
 				if [[ ${LINE,,} =~ .*(error|warn).* ]]; then

--- a/post_build.sh
+++ b/post_build.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 RED='\033[0;31m'
 YELLOW='\033[1;33m'
 BLUE='\033[0;34m'


### PR DESCRIPTION
- Addresses [DIG-1172](https://candig.atlassian.net/browse/DIG-1172)
- Adds an automatically running script to validate the number of running containers based on .env after build
- Logs stderr and any lines from stdout containing "error" or "warning" (with 2 lines of context above/below) into a log file (default: tmp/error.txt)
- Note this removes color from docker building/composing since it switches to "plain" mode when piping to tee.

To test:
- Add ERRORLOG=tmp/error.txt to the end of your .env.
- Run make build-all.
- Ensure there is some output in tmp/error.txt.
- If the build was successful, ensure that a success message in green was printed at the end of the build. If not, a warning message should have appeared. If so, make sure the number of containers it reports are currently running and number of containers it states should be running are correct.

[DIG-1172]: https://candig.atlassian.net/browse/DIG-1172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ