### PR TITLE
Clean federation during `make clean-authx`

### DIFF
--- a/Makefile.authx
+++ b/Makefile.authx
@@ -63,11 +63,24 @@ clean-tyk:
 
 
 #>>>
+# close federation service
+# make clean-federation
+
+#<<<
+clean-federation:
+	source setup_hosts.sh; \
+	docker compose -f lib/candigv2/docker-compose.yml -f lib/federation/docker-compose.yml down || true
+
+	# - remove intermittent docker images
+	docker images --format '{{.Repository}}:{{.Tag}}' | grep -E 'federation' |  xargs -I{} docker rmi --force {}
+
+
+#>>>
 # close all authentication and authorization services
 # make clean-authx
 
 #<<<
-clean-authx: clean-keycloak clean-tyk clean-vault clean-opa
+clean-authx: clean-keycloak clean-tyk clean-vault clean-opa clean-federation
 
 
 #>>>

--- a/Makefile.authx
+++ b/Makefile.authx
@@ -65,7 +65,6 @@ clean-tyk:
 #>>>
 # close federation service
 # make clean-federation
-
 #<<<
 clean-federation:
 	source setup_hosts.sh; \
@@ -90,6 +89,7 @@ clean-authx: clean-keycloak clean-tyk clean-vault clean-opa clean-federation
 #<<<
 init-authx: mkdir
 	$(MAKE) docker-volumes
+	$(foreach MODULE, $(CANDIG_AUTH_MODULES), $(MAKE) build-$(MODULE);)
 	$(foreach MODULE, $(CANDIG_AUTH_MODULES), $(MAKE) compose-$(MODULE);)
 
 


### PR DESCRIPTION
Fix for an issue found where `make clean-all` doesn't remove federation.

**To test**: Running either `make clean-authx` or `make clean-all` should now properly stop & cleanup the federation container/image/volumes.