### PR TITLE
DIG-921: Fix the "Websocket error: Could not connect to ws:// <x>" error

### DIFF
--- a/lib/candig-data-portal/docker-compose.yml
+++ b/lib/candig-data-portal/docker-compose.yml
@@ -24,6 +24,7 @@ services:
       - REACT_APP_FEDERATION_API_SERVER=${FEDERATION_PUBLIC_URL}
       - REACT_APP_BASE_NAME=
       - REACT_APP_SITE_LOCATION=${CANDIG_SITE_LOCATION}
+      - WDS_SOCKET_PORT=0
     healthcheck:
       test: [ "CMD", "curl", "http://localhost:2543" ]
       interval: 30s


### PR DESCRIPTION
[Jira link](https://candig.atlassian.net/browse/DIG-921)

This fixes the candig-data-portal error that would spam the console with `WebSocket connection to 'ws://candig.docker.internal:3000/ws' failed:`.

In addition, this makes linter/prettier errors show up when browsing the web page. Unsure if this is functionality we want, but I found it pretty useful as a reminder.