### PR TITLE
Sonchau/add katsu secret

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -281,10 +281,7 @@ docker-push:
 
 #<<<
 .PHONY: docker-secrets
-docker-secrets: mkdir minio-secrets
-	@echo admin > tmp/secrets/metadata-db-user
-	$(MAKE) secret-metadata-app-secret
-	$(MAKE) secret-metadata-db-secret
+docker-secrets: mkdir minio-secrets katsu-secrets
 
 	@echo admin > tmp/secrets/keycloak-admin-user
 	$(MAKE) secret-keycloak-admin-password
@@ -303,6 +300,8 @@ docker-secrets: mkdir minio-secrets
 
 	$(MAKE) secret-opa-root-token
 	$(MAKE) secret-opa-service-token
+
+
 
 #>>>
 # create persistant volumes for docker containers
@@ -369,7 +368,18 @@ minio-secrets:
 	@echo "aws_access_key_id=`cat tmp/secrets/minio-access-key`" >> tmp/secrets/aws-credentials
 	@echo "aws_secret_access_key=`cat tmp/secrets/minio-secret-key`" >> tmp/secrets/aws-credentials
 
+#>>>
+# make katsu-secret and database secret
 
+#<<<
+katsu-secrets:
+	@echo admin > tmp/secrets/katsu-secret-key
+	@dd if=/dev/urandom bs=1 count=50 2>/dev/null \
+		| base64 | tr -d '\n\r+' | sed s/[^A-Za-z0-9]//g > tmp/secrets/katsu-secret-key
+	
+	@echo admin > tmp/secrets/metadata-db-user
+	$(MAKE) secret-metadata-app-secret
+	$(MAKE) secret-metadata-db-secret
 #>>>
 # pull docker image to $DOCKER_REGISTRY
 # $module is the name of the sub-folder in lib/

--- a/etc/tests/test_integration.py
+++ b/etc/tests/test_integration.py
@@ -430,6 +430,30 @@ def test_katsu_users(user, dataset, not_dataset):
     assert dataset in donors
     assert not_dataset not in donors
 
+def test_katsu_delete():
+    test_loc = "https://raw.githubusercontent.com/CanDIG/katsu/develop/chord_metadata_service/mohpackets/data/small_dataset/synthetic_data/Program.json"
+    response = requests.get(test_loc)
+    assert response.status_code == 200
+
+    site_admin_token = get_token(
+        username=ENV["CANDIG_SITE_ADMIN_USER"],
+        password=ENV["CANDIG_SITE_ADMIN_PASSWORD"],
+    )
+    headers = {
+        "Authorization": f"Bearer {site_admin_token}",
+        "Content-Type": "application/json; charset=utf-8",
+    }
+    
+    program_data = response.json()
+    program_ids = [item["program_id"] for item in program_data]
+
+    for program_id in program_ids:
+        response = requests.delete(
+            f"{ENV['CANDIG_URL']}/katsu/v2/authorized/programs/{program_id}/",
+            headers=headers
+        )
+        assert response.status_code == 204, f"Failed to delete program '{program_id}'. Status code: {response.status_code}"
+        print(f"Deletion of program '{program_id}' was successful.")
 
 ## HTSGet + katsu:
 def test_add_sample_to_genomic():

--- a/lib/candigv2/docker-compose.yml
+++ b/lib/candigv2/docker-compose.yml
@@ -39,6 +39,10 @@ secrets:
     file: $PWD/tmp/federation/services.json
     labels:
       - "candigv2=secret"
+  katsu-secret-key:
+    file: $PWD/tmp/secrets/katsu-secret-key
+    labels:
+      - "candigv2=secret"
   metadata-app-secret:
     file: $PWD/tmp/secrets/metadata-app-secret
     labels:

--- a/lib/katsu/docker-compose.prod.yml
+++ b/lib/katsu/docker-compose.prod.yml
@@ -7,4 +7,4 @@ services:
           katsu_env: "prod"
     environment:
       - DJANGO_SETTINGS_MODULE=config.settings.prod
-      - CONN_MAX_AGE=60
+      - CONN_MAX_AGE=60 # change on traffic and performance

--- a/lib/katsu/docker-compose.prod.yml
+++ b/lib/katsu/docker-compose.prod.yml
@@ -8,3 +8,6 @@ services:
     environment:
       - DJANGO_SETTINGS_MODULE=config.settings.prod
       - CONN_MAX_AGE=60 # change on traffic and performance
+  metadata-db:
+    ports:
+      - "5432:5432"

--- a/lib/katsu/docker-compose.prod.yml
+++ b/lib/katsu/docker-compose.prod.yml
@@ -1,0 +1,6 @@
+version: '3.7'
+
+services:
+  katsu:
+    environment:
+      - DJANGO_SETTINGS_MODULE=config.settings.prod

--- a/lib/katsu/docker-compose.prod.yml
+++ b/lib/katsu/docker-compose.prod.yml
@@ -4,3 +4,4 @@ services:
   katsu:
     environment:
       - DJANGO_SETTINGS_MODULE=config.settings.prod
+      - CONN_MAX_AGE=60

--- a/lib/katsu/docker-compose.prod.yml
+++ b/lib/katsu/docker-compose.prod.yml
@@ -2,6 +2,9 @@ version: '3.7'
 
 services:
   katsu:
+    build:
+        args:
+          katsu_env: "prod"
     environment:
       - DJANGO_SETTINGS_MODULE=config.settings.prod
       - CONN_MAX_AGE=60

--- a/lib/katsu/docker-compose.yml
+++ b/lib/katsu/docker-compose.yml
@@ -24,6 +24,7 @@ services:
       - KATSU_AUTHORIZATION=${CANDIG_AUTHORIZATION}
       - OPA_SITE_ADMIN_KEY=${OPA_SITE_ADMIN_KEY}
       - HOST_CONTAINER_NAME=${KATSU_CONTAINER}
+      - CONN_MAX_AGE=60
       - DJANGO_SETTINGS_MODULE=config.settings.dev
     secrets:
       - source: metadata-db-secret

--- a/lib/katsu/docker-compose.yml
+++ b/lib/katsu/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       args:
         venv_python: "${VENV_PYTHON}"
         alpine_version: "${ALPINE_VERSION}"
+        katsu_env: "dev"
     image: ${DOCKER_REGISTRY}/katsu:${KATSU_VERSION:-latest}
     ports:
       - "${KATSU_PORT}:8000"

--- a/lib/katsu/docker-compose.yml
+++ b/lib/katsu/docker-compose.yml
@@ -30,6 +30,8 @@ services:
         target: metadata_db_secret
       - source: opa-root-token
         target: opa-root-token
+      - source: katsu-secret-key
+        target: katsu_secret
     labels:
       - "candigv2=chord-metadata"
 


### PR DESCRIPTION
What's new:
- add function to make katsu key (50 chars)
- generate katsu secret
- add katsu prod yaml
- add clean up test in test-integration, now katsu should clean itself any extra data after ingest

How to test:
- update katsu to sonchau/part_36
- make test-integration