### PR TITLE
change opa image to latest-static to support arm64

### DIFF
--- a/lib/opa/docker-compose.yml
+++ b/lib/opa/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - "${CANDIG_DOMAIN}:${LOCAL_IP_ADDR}"
 
   opa:
-    image: openpolicyagent/opa:latest
+    image: openpolicyagent/opa:latest-static
     labels:
       - "candigv2=opa"
     ports:


### PR DESCRIPTION
Minor change to the opa image label from `latest` to `latest-static`. From the [OPA dockerhub page](https://hub.docker.com/r/openpolicyagent/opa/), the static tag includes a statically linked executable. Importantly, the static tag supports both arm64 and amd64 architectures. This avoids having to manually edit `opa/lib/docker-compose.yml` after every pull on M1. Or, more accurately, pulling + forgetting to update + wondering why the build failed + seeing the incompatibility tag on Docker Desktop and _then_ changing the tag. 