### PR TITLE
DIG-1273: Add more endpoints to the Tyk test, and add a timeout

### DIFF
--- a/etc/tests/test_integration.py
+++ b/etc/tests/test_integration.py
@@ -61,14 +61,17 @@ def test_tyk():
     endpoints = [f"{ENV['CANDIG_ENV']['TYK_HTSGET_API_LISTEN_PATH']}/ga4gh/drs/v1/service-info",
         f"{ENV['CANDIG_ENV']['TYK_KATSU_API_LISTEN_PATH']}/v2/version_check",
         f"{ENV['CANDIG_ENV']['TYK_FEDERATION_API_LISTEN_PATH']}/v1/service-info",
-        F"{ENV['CANDIG_ENV']['TYK_OPA_API_LISTEN_PATH']}/v1/data/paths"]
+        f"{ENV['CANDIG_ENV']['TYK_OPA_API_LISTEN_PATH']}/v1/data/paths"]
+    responses = []
     for endpoint in endpoints:
         response = requests.get(
             f"{ENV['CANDIG_URL']}/{endpoint}",
             headers=headers,
             timeout=10
         )
-        assert response.status_code == 200
+        responses.append(response.status_code)
+        print(f"{endpoint}: {response.status_code == 200}")
+    assert all(response == 200 for response in responses)
 
 
 ## Opa tests:
@@ -449,7 +452,7 @@ def test_katsu_delete():
         "Authorization": f"Bearer {site_admin_token}",
         "Content-Type": "application/json; charset=utf-8",
     }
-    
+
     program_data = response.json()
     program_ids = [item["program_id"] for item in program_data]
 

--- a/etc/tests/test_integration.py
+++ b/etc/tests/test_integration.py
@@ -53,16 +53,22 @@ def test_get_token():
     )
 
 
-## Tyk test: can we get a response from Tyk for a service?
+## Tyk test: can we get a response from Tyk for all of our services?
 def test_tyk():
     headers = {
         "Authorization": f"Bearer {get_token(username=ENV['CANDIG_SITE_ADMIN_USER'], password=ENV['CANDIG_SITE_ADMIN_PASSWORD'])}"
     }
-    response = requests.get(
-        f"{ENV['CANDIG_URL']}/{ENV['CANDIG_ENV']['TYK_HTSGET_API_LISTEN_PATH']}/ga4gh/drs/v1/service-info",
-        headers=headers,
-    )
-    assert response.status_code == 200
+    endpoints = [f"{ENV['CANDIG_ENV']['TYK_HTSGET_API_LISTEN_PATH']}/ga4gh/drs/v1/service-info",
+        f"{ENV['CANDIG_ENV']['TYK_KATSU_API_LISTEN_PATH']}/v2/version_check",
+        f"{ENV['CANDIG_ENV']['TYK_FEDERATION_API_LISTEN_PATH']}/v1/service-info",
+        F"{ENV['CANDIG_ENV']['TYK_OPA_API_LISTEN_PATH']}/v1/data/paths"]
+    for endpoint in endpoints:
+        response = requests.get(
+            f"{ENV['CANDIG_URL']}/{endpoint}",
+            headers=headers,
+            timeout=10
+        )
+        assert response.status_code == 200
 
 
 ## Opa tests:


### PR DESCRIPTION
[Jira ticket](https://candig.atlassian.net/browse/DIG-1273)

This PR makes sure Tyk is able to communicate with all endpoints, rather than just HTSGet.

**To test**:
Setup the entire stack, as usual, then:
1. Check that the Test_Tyk works if the entire setup is working, and then:
2. Fails if either OPA, Federation, HTSGet, or Katsu are down

You can run this specific test with `python settings.py; source env.sh; pytest ./etc/tests -k "Test_Tyk"`, or by running all integration tests (make test-integration).