### PR TITLE
DIG-1282: Fix docker-compose dependency issues & GitHub Actions

### DIFF
--- a/.github/workflows/candig-testing.yml
+++ b/.github/workflows/candig-testing.yml
@@ -2,7 +2,7 @@ name: Test-CanDIG-build
 run-name: Build Validation
 on: 
   push:
-    branches: [develop]
+    branches: [develop, actions-hotfix]
   pull_request:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/candig-testing.yml
+++ b/.github/workflows/candig-testing.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup environment file
         run: | 
             cp etc/env/example.env example.env
-            sed "286s@bin/miniconda3@$CONDA@" example.env > .env
+            sed "s@CONDA_INSTALL=.*@CONDA_INSTALL=$CONDA@" example.env > .env
       - name: Display environment file
         run: cat ".env"
       - name: Add CanDIG local domain redirection to hosts

--- a/.github/workflows/candig-testing.yml
+++ b/.github/workflows/candig-testing.yml
@@ -2,7 +2,7 @@ name: Test-CanDIG-build
 run-name: Build Validation
 on: 
   push:
-    branches: [develop, actions-hotfix]
+    branches: [develop]
   pull_request:
   workflow_dispatch:
     inputs:

--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,8 @@ SHELL = bash
 #  and then use make mkdir and make init-conda (no bin-conda, which will blow up an existing conda)
 # <<<
 
-CONDA = $(CONDA_INSTALL)/miniconda3/bin/conda
-CONDA_ENV_SETTINGS = $(CONDA_INSTALL)/miniconda3/etc/profile.d/conda.sh
+CONDA = $(CONDA_INSTALL)/bin/conda
+CONDA_ENV_SETTINGS = $(CONDA_INSTALL)/etc/profile.d/conda.sh
 
 LOGFILE = tmp/progress.txt
 
@@ -62,7 +62,7 @@ endif
 ifeq ($(VENV_OS), linux)
 	curl -Lo bin/miniconda_install.sh \
 		https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
-	bash bin/miniconda_install.sh -f -b -u -p $(CONDA_INSTALL)/miniconda3
+	bash bin/miniconda_install.sh -f -b -u -p $(CONDA_INSTALL)
 	# init is needed to create bash aliases for conda but it won't work
 	# until you source the script that ships with conda
 	source $(CONDA_ENV_SETTINGS) && $(CONDA) init
@@ -71,7 +71,7 @@ endif
 ifeq ($(VENV_OS), darwin)
 	curl -Lo bin/miniconda_install.sh \
 		https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
-	bash bin/miniconda_install.sh -f -b -u -p $(CONDA_INSTALL)/miniconda3
+	bash bin/miniconda_install.sh -f -b -u -p $(CONDA_INSTALL)
 	# init is needed to create bash aliases for conda but it won't work
 	# until you source the script that ships with conda
 	source $(CONDA_ENV_SETTINGS) && $(CONDA) init
@@ -80,7 +80,7 @@ endif
 ifeq ($(VENV_OS), arm64mac)
 	curl -Lo bin/miniconda_install.sh \
 		https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-arm64.sh
-	bash bin/miniconda_install.sh -f -b -u -p $(CONDA_INSTALL)/miniconda3
+	bash bin/miniconda_install.sh -f -b -u -p $(CONDA_INSTALL)
 	# init is needed to create bash aliases for conda but it won't work
 	# until you source the script that ships with conda
 	source $(CONDA_ENV_SETTINGS) && $(CONDA) init zsh

--- a/docs/install-docker.md
+++ b/docs/install-docker.md
@@ -52,6 +52,8 @@ sudo systemctl start docker
 sudo usermod -aG docker $(whoami)
 ```
 
+Note that CanDIG requires **Docker Compose v2**, which is provided alongside the latest version of Docker. Versions of Docker which do not provide Docker Compose will unfortunately not work with CanDIG.
+
 ### CentOS 7
 
 1. Update system/install dependencies

--- a/etc/env/example.env
+++ b/etc/env/example.env
@@ -287,4 +287,4 @@ CANDIG_INGEST_PORT=1235
 # error logging
 ERRORLOG=tmp/error.txt
 
-CONDA_INSTALL=bin
+CONDA_INSTALL=bin/miniconda3

--- a/etc/venv/requirements.txt
+++ b/etc/venv/requirements.txt
@@ -1,4 +1,3 @@
-docker-compose
 docker
 python-dotenv
 tox


### PR DESCRIPTION
- Removes docker-compose from the Conda install requirements
- Fixes the Conda install location for GitHub Actions
    - NOTE: This will require a new CONDA_INSTALL_LOCATION value in your .env, see the example.env