### PR TITLE
Add ingest to the Tyk configuration

### DIFF
--- a/etc/env/example.env
+++ b/etc/env/example.env
@@ -124,7 +124,7 @@ FEDERATION_SERVICES=katsu htsget
 define FEDERATION_SELF_SERVER="
 {
     'id': 'internal-1',
-    'url': '${FEDERATION_PUBLIC_URL}',
+    'url': '${FEDERATION_SERVICE_URL}/${TYK_FEDERATION_API_LISTEN_PATH}',
     'location': {
         'name': 'Local',
         'province': 'ON',
@@ -181,6 +181,7 @@ TYK_SERVICE_PUBLIC_PORT=5080
 TYK_SERVICE_HOST=0.0.0.0
 #TODO: consolidate tyk public and private domains
 TYK_LOGIN_TARGET_URL=http://${CANDIG_DOMAIN}:${TYK_SERVICE_PUBLIC_PORT}
+TYK_PRIVATE_URL=http://${CANDIG_DOMAIN}:${TYK_SERVICE_PUBLIC_PORT}
 TYK_ANALYTICS_FROM_EMAIL=admin@distributedgenomics.ca
 TYK_ANALYTICS_FROM_NAME=CanDIG Admin
 TYK_LISTEN_PATH=
@@ -239,6 +240,14 @@ TYK_FEDERATION_API_SLUG=federation
 TYK_FEDERATION_API_TARGET=${FEDERATION_SERVICE_URL}
 TYK_FEDERATION_API_LISTEN_PATH=federation
 
+## api - ingest
+CANDIG_INGEST_VERSION=1.0.1
+CANDIG_INGEST_PORT=1235
+TYK_INGEST_API_ID=101
+TYK_INGEST_API_SLUG=ingest
+TYK_INGEST_API_TARGET=http://${CANDIG_DOMAIN}:${CANDIG_INGEST_PORT}
+TYK_INGEST_API_LISTEN_PATH=ingest
+
 ## Extra APIs can be added here
 ## api - example
 #TYK_EXAMPLE_API_ID=666
@@ -279,10 +288,6 @@ CANDIG_DATA_PORTAL_PRIVATE_URL=http://candig-data-portal:3000
 # vault helper tool
 TOKEN_PATH = ${PWD}/Vault-Helper-Tool/token.txt
 PROGRESS_FILE = ${PWD}/tmp/progress.txt
-
-# candig ingest
-CANDIG_INGEST_VERSION=1.0.1
-CANDIG_INGEST_PORT=1235
 
 # error logging
 ERRORLOG=tmp/error.txt

--- a/lib/tyk/configuration_templates/api_ingest.json.tpl
+++ b/lib/tyk/configuration_templates/api_ingest.json.tpl
@@ -1,0 +1,151 @@
+{
+    "api_id": "${TYK_INGEST_API_ID}",
+    "name": "${TYK_INGEST_API_SLUG}",
+    "use_openid": true,
+    "active": true,
+    "slug": "${TYK_INGEST_API_SLUG}",
+
+    "enable_signature_checking": false,
+
+    "jwt_issued_at_validation_skew": 0,
+    "jwt_expires_at_validation_skew": 0,
+    "upstream_certificates": {},
+    "use_keyless": false,
+    "enable_coprocess_auth": false,
+    "base_identity_provided_by": "",
+    
+    "proxy": {
+        "target_url": "${TYK_INGEST_API_TARGET}",
+        "strip_listen_path": true,
+        "disable_strip_slash": false,
+        "listen_path": "/${TYK_INGEST_API_LISTEN_PATH}",
+        "transport": {
+            "ssl_insecure_skip_verify": false,
+            "ssl_ciphers": [],
+            "ssl_min_version": 0,
+            "proxy_url": ""
+        },
+        "target_list": [],
+        "preserve_host_header": false
+    },
+
+    "version_data": {
+        "not_versioned": true,
+        "versions": {
+            "Default": {
+            "name": "Default",
+            "use_extended_paths": true
+            }
+        },
+        "extended_paths": {
+            "ignored": [
+                {
+                    "path": "${KEYCLOAK_LOGIN_REDIRECT_PATH}",
+                    "method_actions": {
+                        "GET": {
+                            "action": "no_action",
+                            "code": 200,
+                            "headers": {}
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    "custom_middleware": {
+        "pre": [
+                {
+                "name": "backendAuthMiddleware",
+                "path": "/opt/tyk-gateway/middleware/backendAuthMiddleware.js",
+                "require_session": false
+            }
+            ],
+        "post": [],
+        "id_extractor": {
+            "extract_with": "",
+            "extract_from": "",
+            "extractor_config": {}
+        },
+        "driver": "",
+        "auth_check": {
+            "path": "",
+            "require_session": false,
+            "name": ""
+        },
+        "post_key_auth": [],
+        "response": []
+    },
+    
+    "config_data": {
+        "TYK_SERVER": "${TYK_LOGIN_TARGET_URL}",
+        "KEYCLOAK_SECRET": "${KEYCLOAK_SECRET}",
+        "KEYCLOAK_REALM": "${KEYCLOAK_REALM}",
+        "KEYCLOAK_CLIENT_ID": "${KEYCLOAK_CLIENT_ID}",
+        "KEYCLOAK_PRIVATE_URL": "${KEYCLOAK_PRIVATE_URL}",
+        "VAULT_SERVICE_URL":"${VAULT_SERVICE_URL}",
+        "VAULT_SERVICE_RESOURCE":"/v1/auth/jwt/login",
+        "VAULT_ROLE":"researcher"
+    },
+    "openid_options": {
+    "segregate_by_client": false,
+    "providers": [
+            {
+                "issuer": "${KEYCLOAK_PUBLIC_URL}/auth/realms/${KEYCLOAK_REALM}",
+                "client_ids": {
+                    "${KEYCLOAK_CLIENT_ID_64}": "${TYK_POLICY_ID}"
+                }
+            }
+        ]
+    },
+
+
+    "definition": {
+        "location": "header",
+        "key": "x-api-version"
+    },
+
+
+    "internal": false,
+    "jwt_skip_kid": false,
+    "enable_batch_request_support": false,
+    "response_processors": [],
+    "use_mutual_tls_auth": false,
+    "basic_auth": {
+        "disable_caching": false,
+        "cache_ttl": 0,
+        "extract_from_body": false,
+        "body_user_regexp": "",
+        "body_password_regexp": ""
+    },
+    "use_standard_auth": false,
+    "session_lifetime": 0,
+    "use_oauth2": false,
+    "jwt_source": "",
+    "jwt_signing_method": "",
+    "jwt_not_before_validation_skew": 0,
+    "jwt_identity_base_field": "",
+
+    "session_provider": {
+        "name": "",
+        "storage_engine": "",
+        "meta": {}
+    },
+
+    "auth": {
+        "use_param": false,
+        "param_name": "",
+        "use_cookie": false,
+        "cookie_name": "",
+        "auth_header_name": "",
+        "use_certificate": false,
+        "validate_signature": false,
+        "signature": {
+            "algorithm": "",
+            "header": "",
+            "secret": "",
+            "allowed_clock_skew": 0,
+            "error_code": 0,
+            "error_message": ""
+        }
+    }
+}

--- a/lib/tyk/configuration_templates/policies.json.tpl
+++ b/lib/tyk/configuration_templates/policies.json.tpl
@@ -56,6 +56,14 @@
                 "versions": [
                     "Default"
                 ]
+            },
+            "${TYK_INGEST_API_ID}": {
+                "allowed_urls": [],
+                "api_id": "${TYK_INGEST_API_ID}",
+                "api_name": "${TYK_INGEST_API_SLUG}",
+                "versions": [
+                    "Default"
+                ]
             }
         },
         "active": true,

--- a/lib/tyk/tyk_preflight.sh
+++ b/lib/tyk/tyk_preflight.sh
@@ -76,6 +76,9 @@ envsubst < ${PWD}/lib/tyk/configuration_templates/api_katsu.json.tpl > ${CONFIG_
 echo "Working on api_candig_data_portal.json"
 envsubst < ${PWD}/lib/tyk/configuration_templates/api_mcode_candig_data_portal.json.tpl > ${CONFIG_DIR}/apps/${TYK_CANDIG_DATA_PORTAL_API_ID}.json
 
+echo "Working on api_ingest.json"
+envsubst < ${PWD}/lib/tyk/configuration_templates/api_ingest.json.tpl > ${CONFIG_DIR}/apps/${TYK_INGEST_API_ID}.json
+
 echo "Working on api_graphql.json"
 envsubst < ${PWD}/lib/tyk/configuration_templates/api_graphql.json.tpl > ${CONFIG_DIR}/apps/${TYK_GRAPHQL_API_ID}.json
 

--- a/lib/tyk/tyk_setup.sh
+++ b/lib/tyk/tyk_setup.sh
@@ -71,6 +71,11 @@ generate_key() {
               "api_id": "'"${TYK_VAULT_API_ID}"'",
               "api_name": "'"${TYK_VAULT_API_SLUG}"'",
               "Versions": ["Default"]
+          },
+          "'"${TYK_INGEST_API_ID}"'": {
+              "api_id": "'"${TYK_INGEST_API_ID}"'",
+              "api_name": "'"${TYK_INGEST_API_SLUG}"'",
+              "Versions": ["Default"]
           }
       }
   }'


### PR DESCRIPTION
**This requires a change to the .env file**

# Description
This adds the candig ingest microservice to Tyk, allowing requests to ${CANDIG_URL}/ingest to point to the ingest microservice, and transforming Keycloak cookies to bearer tokens.

# To test
- All things accessible through candig.docker.internal:1235 should also be accessible through candig.docker.internal:5080/ingest
- Authenticated requests should work properly as well