### PR TITLE
Update services and components list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Optional modules follow the `#` and include federation service, various monitori
 
 For federated installations, you will need `federation-service`.
 
-For production deployments, you will probably want to include  `federation-service`. Be aware that the last three require more resources, includeing storage.
+For production deployments, you will probably want to include  `federation-service`.
 
 Authorization and authentication modules defined in  `CANDIG_AUTH_MODULES` are only installed if you run `make init-authx` during deployment.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ CanDIGv2/
  |    ├── tests/                   - integration tests (under development)
  │    ├── venv/                    - dependency files for virtualenvs (conda, pip, etc.)
  │    └── yml/                     - various yaml based configs (toil, traefik, etc.)
- ├── lib/                          - contains modules of servies/apps
+ ├── lib/                          - contains modules of services/apps
  └── tmp/                          - contains temporary files used for runtime functionality
       ├── configs/                 - config files that are added to services post-deployment
       ├── data/                    - local data for running services
@@ -32,6 +32,32 @@ CanDIGv2/
       ├── vault/                   - vault keys
       └── secrets/                 - directory to store randomly generated secrets for service deployment
 ```
+
+## List of Services and Components
+
+The following table lists the individual repos for each service and helper library developed by the CanDIG team that contribute to the CanDIGv2 stack.
+
+| Service/Component Name    | Source                                                                | Description                       |
+|---------------------------|-----------------------------------------------------------------------|------------------------------|
+| authx                     | [`candigv2-authx`](https://github.com/CanDIG/candigv2-authx)          | Library to facilitate interacting with AuthZ/AuthN services, Keycloak, Tyk, Opa, Vault & Access to minIO S3 objects | 
+| CanDIG Data Portal        | [`candig-data-portal`](https://github.com/CanDIG/candig-data-portal)  | Front-end User interface for CanDIG Services |
+| CanDIG Ingest Service     | [`candig-ingest`](https://github.com/CanDIG/candig-ingest)            | Ingests clinical and genomic data into the CanDIG infrastructure. As at September 2023, still being integrated into the stack. |
+| Clinical ETL Code         | [`clinical_ETL_code`](https://github.com/CanDIG/clinical_ETL_code)    | Code to convert spreadsheet format into the MoH data model in preparation for ingest into `katsu` |
+| Federation Service        | [`federation-service`](https://github.com/CanDIG/federation_service)  | Distributes requests across each federated node of the distributed infrastructure   |
+| HTSGet                    | [`htsget_app`](https://github.com/CanDIG/htsget_app)                  | Implementation of GA4GH htsget API which ingests and indexes VCF files and stores GA4GH DRS objects for retrieval |
+| Katsu                     | [`katsu`](https://github.com/CanDIG/katsu)                            | Manages the clinical metadata in a PostgreSQL database |
+| CanDIG OPA                | [`candig-opa`](https://github.com/CanDIG/candig-opa)                  | Manages role-based access policies   |
+| Query service             | [`query`](https://github.com/CanDIG/candig-opa)                       | as at September 2023, still being integrated into the stack |
+
+As well as in-house developed services, the CanDIG stack relies on external software which is configured to work within the stack, configurations are found in the [`/lib`](/lib) folder for each software, these include:
+
+| Service/Component Name                  | Role                                 |  
+|-----------------------------------------|--------------------------------------|
+| [Keycloak](https://www.keycloak.org/)   | Authentication management            |
+| [minio](https://min.io/)                | Object storage for genomic files     |
+| [OPA](https://www.openpolicyagent.org/) | Manages role-based access policies   |
+| [Tyk](https://tyk.io/)                  | API management and redirection       |
+| [Vault](https://www.vaultproject.io/)   | Secret and password management       |
 
 ## `.env` Environment File
 
@@ -67,13 +93,15 @@ Not all CanDIG modules are required for a minimal installation. The `CANDIG_MODU
 
 By default (if you copy the sample file from `etc/env/example.env`) the installation includes the minimal list of modules:
 
+```
   CANDIG_MODULES=minio htsget-server katsu candig-data-portal
+```
 
 Optional modules follow the `#` and include federation service, various monitoring components, workflow execution, and some older modules not generally installed.
 
 For federated installations, you will need `federation-service`.
 
-For production deployments, you will probably want to include  `federation-service weavescope logging monitoring`. Be aware that the last three require more resources, includeing storage.
+For production deployments, you will probably want to include  `federation-service`. Be aware that the last three require more resources, includeing storage.
 
 Authorization and authentication modules defined in  `CANDIG_AUTH_MODULES` are only installed if you run `make init-authx` during deployment.
 
@@ -89,21 +117,7 @@ There are other deprecated deployment guides in `docs`, but there are no guarant
 
 View additional Makefile options with `make help`.
 
-## Services and Components
-
-### Add new service
+## Add new service
 
 New services can be added under `lib` directory.  Please refer to the
 [template for new services README](./lib/templates/README.md) for more details.
-
-### List of services
-
-The following table lists the details from the Data Flow Diagram in the "Overview" section.
-
-| Service/Component Name | Source | Notes                        |
-|------------------------|--------|------------------------------|
-| Katsu                  | links  | DFD: `katsu`        |
-| Federation Service     | links  | DFD: `federation_service`    |
-| HTSGet                 | links  | DFD: `htsget_app`            |
-| WES Server             | links  | DFD: `wes_server`            |
-| CanDIG Data Portal     | links  | DFD: `candig-data-portal`    |

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The following table lists the individual repos for each service and helper libra
 |---------------------------|-----------------------------------------------------------------------|------------------------------|
 | authx                     | [`candigv2-authx`](https://github.com/CanDIG/candigv2-authx)          | Library to facilitate interacting with AuthZ/AuthN services, Keycloak, Tyk, Opa, Vault & Access to minIO S3 objects | 
 | CanDIG Data Portal        | [`candig-data-portal`](https://github.com/CanDIG/candig-data-portal)  | Front-end User interface for CanDIG Services |
-| CanDIG Ingest Service     | [`candig-ingest`](https://github.com/CanDIG/candig-ingest)            | Ingests clinical and genomic data into the CanDIG infrastructure. As at September 2023, still being integrated into the stack. |
+| CanDIGv2 Ingest Service     | [`candig-ingest`](https://github.com/CanDIG/candigv2-ingest)        | Ingests clinical and genomic data into the CanDIG infrastructure. As at September 2023, still being integrated into the stack. |
 | Clinical ETL Code         | [`clinical_ETL_code`](https://github.com/CanDIG/clinical_ETL_code)    | Code to convert spreadsheet format into the MoH data model in preparation for ingest into `katsu` |
 | Federation Service        | [`federation-service`](https://github.com/CanDIG/federation_service)  | Distributes requests across each federated node of the distributed infrastructure   |
 | HTSGet                    | [`htsget_app`](https://github.com/CanDIG/htsget_app)                  | Implementation of GA4GH htsget API which ingests and indexes VCF files and stores GA4GH DRS objects for retrieval |


### PR DESCRIPTION
- Update services and components table
- rearrange order to have services up front
- fixed a typo and added code type formatting
- removed `weavescope logging monitoring` from the deployment instructions because I don't believe they are used anymore, should these also be removed from the `lib` directory? Then again I also believe that we will reinstate them soon, maybe next sprint so maybe not worth fully removing

Reviewer to check the list to see whether anything is missing and the descriptions seem to make sense.

I rearranged ordering to have the services upfront but open to it moving back lower depending on what people think. Possibly thought having the list up front is a handy index.
