### PR TITLE
DIG-1318: Opa starts up with only its own keycloak IDP

### DIFF
--- a/lib/opa/docker-compose.yml
+++ b/lib/opa/docker-compose.yml
@@ -15,18 +15,16 @@ services:
     volumes:
       - opa-data:/app
     secrets:
-      - source: keycloak-client-local-candig-secret
-        target: idp_client_secret
       - source: opa-root-token
         target: opa-root-token
       - source: opa-service-token
         target: opa-service-token
     environment:
-      IDP_CLIENT_ID: ${KEYCLOAK_CLIENT_ID}
+      KEYCLOAK_CLIENT_ID: ${KEYCLOAK_CLIENT_ID}
       OPA_SITE_ADMIN_KEY: ${OPA_SITE_ADMIN_KEY}
       OPA_URL: ${OPA_URL}
-      IDP: "${KEYCLOAK_PUBLIC_URL}/auth/realms/${KEYCLOAK_REALM}"
-      KATSU_URL: "${KATSU_PUBLIC_URL}"
+      KEYCLOAK_REALM_URL: ${KEYCLOAK_REALM_URL}
+      KATSU_URL: ${KATSU_PUBLIC_URL}
     extra_hosts:
       - "${CANDIG_DOMAIN}:${LOCAL_IP_ADDR}"
 
@@ -38,8 +36,6 @@ services:
       - "${OPA_PORT}:8181"
     volumes:
       - opa-data:/app
-    environment:
-      IDP: ${KEYCLOAK_REALM_URL}
     command:
       - "run"
       - "--server"

--- a/lib/opa/opa_setup.sh
+++ b/lib/opa/opa_setup.sh
@@ -19,7 +19,6 @@ sleep 5
 opa_runner=$(docker ps -a --format "{{.Names}}" | grep "opa-runner" | awk '{print $1}')
 opa_container=$(docker ps -a --format "{{.Names}}" | grep "opa_" | awk '{print $1}')
 
-docker exec $opa_runner python3 app/permissions_engine/fetch_keys.py
 docker start $opa_container
 
 # docker exec $opa_runner python3 app/tests/create_katsu_test_datasets.py


### PR DESCRIPTION
This picks up the submodule change in https://github.com/CanDIG/candig-opa/pull/38 and updates the docker-compose's envvars to pick up the corresponding name changes.

I also removed some unused lines from the docker-compose and one from opa_setup.sh.