### PR TITLE
Add requirements for HTSGet to access Postgres

### DIFF
--- a/etc/env/example.env
+++ b/etc/env/example.env
@@ -2,7 +2,7 @@
 # - - -
 
 # site options
-CANDIG_MODULES=minio htsget katsu candig-data-portal candig-ingest #drs-server wes-server logging monitoring
+CANDIG_MODULES=minio postgres htsget katsu candig-data-portal candig-ingest #drs-server wes-server logging monitoring
 CANDIG_AUTH_MODULES=keycloak tyk opa vault federation
 
 # options are [<ip_addr>, <url>, host.docker.internal, candig.docker.internal]

--- a/etc/tests/test_integration.py
+++ b/etc/tests/test_integration.py
@@ -307,7 +307,7 @@ def test_htsget_access_data(user, obj, access):
         headers=headers,
         params=params,
     )
-    print(f"{ENV['CANDIG_URL']}/genomics/htsget/v1/v1/variants/data/{obj}")
+    print(f"{ENV['CANDIG_URL']}/genomics/htsget/v1/variants/data/{obj}")
     assert (response.status_code == 200) == access
 
 

--- a/lib/htsget/docker-compose.yml
+++ b/lib/htsget/docker-compose.yml
@@ -22,6 +22,10 @@ services:
         target: minio-access-key
       - source: minio-secret-key
         target: minio-secret-key
+      - source: metadata-db-secret
+        target: metadata-db-secret
+      - source: metadata-db-user
+        target: metadata-db-user
     environment:
       HTSGET_TEST_KEY: "hoodlebug"
       HTSGET_URL: ${TYK_LOGIN_TARGET_URL}/${TYK_HTSGET_API_LISTEN_PATH}
@@ -33,5 +37,10 @@ services:
       DB_PATH: /data/files.db
       SERVER_LOCAL_DATA: /app/htsget_server/data
       TESTENV_URL: ${HTSGET_PRIVATE_URL}
+      POSTGRES_DATABASE: "genomic"
+      POSTGRES_HOST_FILE: "metadata-db"
+      POSTGRES_POST: 5433
+      POSTGRES_USERNAME_FILE: "/run/secrets/metadata-db-user"
+      POSTGRES_PASSWORD_FILE: "/run/secrets/metadata-db-secret"
     extra_hosts:
       - "${CANDIG_DOMAIN}:${LOCAL_IP_ADDR}"

--- a/lib/htsget/docker-compose.yml
+++ b/lib/htsget/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       CANDIG_VAULT_URL: ${VAULT_SERVICE_URL}
       MINIO_URL: ${MINIO_PRIVATE_URL}
       DEBUG_MODE: ${CANDIG_DEBUG_MODE}
-      DB_PATH: /data/files.db
+      DB_PATH: "metadata-db"
       SERVER_LOCAL_DATA: /app/htsget_server/data
       TESTENV_URL: ${HTSGET_PRIVATE_URL}
       POSTGRES_DATABASE: "genomic"

--- a/lib/katsu/docker-compose.yml
+++ b/lib/katsu/docker-compose.yml
@@ -11,8 +11,6 @@ services:
     image: ${DOCKER_REGISTRY}/katsu:${KATSU_VERSION:-latest}
     ports:
       - "${KATSU_PORT}:8000"
-    depends_on:
-      - metadata-db
     extra_hosts:
       - "${CANDIG_DOMAIN}:${LOCAL_IP_ADDR}"
     environment:
@@ -34,29 +32,6 @@ services:
         target: opa-root-token
       - source: katsu-secret-key
         target: katsu_secret
-    labels:
-      - "candigv2=chord-metadata"
-
-  metadata-db:
-    image: postgres:15-alpine
-    #volumes:
-      #- katsu-db:/var/lib/postgresql/data
-      #add volume name to lib/{compose,swarm,kubernetes}
-      #add volume name to docker-volumes in Makefile
-    ports:
-      - "5433:5432"
-    environment:
-      - POSTGRES_USER=admin
-      - POSTGRES_DB=metadata
-      - POSTGRES_PASSWORD_FILE=/run/secrets/metadata_db_secret
-      - POSTGRES_HOST_AUTH_METHOD=password
-    extra_hosts:
-      - "${CANDIG_DOMAIN}:${LOCAL_IP_ADDR}"
-    volumes:
-      - postgres-data:/var/lib/postgresql/data
-    secrets:
-      - source: metadata-db-secret
-        target: metadata_db_secret
     labels:
       - "candigv2=chord-metadata"
 

--- a/lib/postgres/docker-compose.yml
+++ b/lib/postgres/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '3.7'
+
+services:
+  metadata-db:
+    image: postgres:15-alpine
+    #volumes:
+      #- katsu-db:/var/lib/postgresql/data
+      #add volume name to lib/{compose,swarm,kubernetes}
+      #add volume name to docker-volumes in Makefile
+    ports:
+      - "5433:5432"
+    environment:
+      - POSTGRES_USER=admin
+      - POSTGRES_DB=metadata
+      - POSTGRES_PASSWORD_FILE=/run/secrets/metadata_db_secret
+      - POSTGRES_HOST_AUTH_METHOD=password
+    extra_hosts:
+      - "${CANDIG_DOMAIN}:${LOCAL_IP_ADDR}"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    secrets:
+      - source: metadata-db-secret
+        target: metadata_db_secret
+    labels:
+      - "candigv2=chord-metadata"
+

--- a/settings.py
+++ b/settings.py
@@ -74,6 +74,7 @@ def get_env():
         vars["TYK_SECRET_KEY"] = f.read().splitlines().pop()
     vars["POSTGRES_PASSWORD_FILE"] = f"tmp/secrets/metadata-db-secret"
     vars["CANDIG_ENV"] = INTERPOLATED_ENV
+    vars["DB_PATH"] = "metadata-db"
     return vars
 
 

--- a/settings.py
+++ b/settings.py
@@ -72,6 +72,7 @@ def get_env():
         vars["MINIO_SECRET_KEY"] = f.read().splitlines().pop()
     with open(f"tmp/secrets/tyk-secret-key") as f:
         vars["TYK_SECRET_KEY"] = f.read().splitlines().pop()
+    vars["POSTGRES_PASSWORD_FILE"] = f"tmp/secrets/metadata-db-secret"
     vars["CANDIG_ENV"] = INTERPOLATED_ENV
     return vars
 


### PR DESCRIPTION
# Jira tickets
[DIG-1308](https://candig.atlassian.net/browse/DIG-1308)
[DIG-1309](https://candig.atlassian.net/browse/DIG-1309)

# Description
This PR switches HTSGet from using a sqlite backend to Postgres, This also renames the `ncbiRefSeq` table to `ncbirefseq`, as the backend requires it, and its value of `end` to `endpos` (internally only), as `end` is a keyword in Postgres.

# Related
This requires a change to HTSGet as well, in [this PR](https://github.com/CanDIG/htsget_app/pull/271).

# To test:
- Should just run integration-tests I think.
- This involves changes to HTSGet, so that submodule needs to be updated

[DIG-1308]: https://candig.atlassian.net/browse/DIG-1308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DIG-1309]: https://candig.atlassian.net/browse/DIG-1309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ