### PR TITLE
DIG-1342: update ingest to cleaned-up version

### DIFF
--- a/etc/env/example.env
+++ b/etc/env/example.env
@@ -2,8 +2,8 @@
 # - - -
 
 # site options
-CANDIG_MODULES=minio postgres htsget katsu candig-data-portal candig-ingest query #drs-server wes-server logging monitoring
-CANDIG_AUTH_MODULES=keycloak tyk opa vault federation
+CANDIG_MODULES=minio postgres htsget katsu candig-data-portal query #drs-server wes-server logging monitoring
+CANDIG_AUTH_MODULES=keycloak tyk opa vault federation candig-ingest
 
 # options are [<ip_addr>, <url>, host.docker.internal, candig.docker.internal]
 CANDIG_DOMAIN=candig.docker.internal

--- a/lib/candig-ingest/docker-compose.yml
+++ b/lib/candig-ingest/docker-compose.yml
@@ -22,5 +22,5 @@ services:
         extra_hosts:
               - "${CANDIG_DOMAIN}:${LOCAL_IP_ADDR}"
         secrets:
-          - source: "keycloak-client-${KEYCLOAK_CLIENT_ID}-secret"
+          - source: keycloak-client-local-candig-secret
             target: keycloak-secret

--- a/lib/candig-ingest/docker-compose.yml
+++ b/lib/candig-ingest/docker-compose.yml
@@ -22,5 +22,5 @@ services:
         extra_hosts:
               - "${CANDIG_DOMAIN}:${LOCAL_IP_ADDR}"
         secrets:
-          - source: keycloak-client-local-candig-secret
+          - source: "keycloak-client-${KEYCLOAK_CLIENT_ID}-secret"
             target: keycloak-secret

--- a/lib/candig-ingest/docker-compose.yml
+++ b/lib/candig-ingest/docker-compose.yml
@@ -16,8 +16,11 @@ services:
             KEYCLOAK_PUBLIC_URL: "${KEYCLOAK_PUBLIC_URL}"
             CANDIG_URL: "http://${CANDIG_DOMAIN}:5080"
             VAULT_URL: "http://${CANDIG_DOMAIN}:${VAULT_SERVICE_PORT}"
-            CANDIG_CLIENT_ID: "${CANDIG_CLIENT_ID}"
-            CANDIG_CLIENT_SECRET: "${CANDIG_CLIENT_SECRET}"
+            CANDIG_CLIENT_ID: "${KEYCLOAK_CLIENT_ID}"
+            CANDIG_SECRET_FILE: "/run/secrets/keycloak-secret"
             OPA_URL: "${OPA_URL}"
         extra_hosts:
               - "${CANDIG_DOMAIN}:${LOCAL_IP_ADDR}"
+        secrets:
+          - source: keycloak-client-local-candig-secret
+            target: keycloak-secret


### PR DESCRIPTION

The ingest docker-compose had a couple of environment variables that should be set through the .env file itself (and the secrets), not relying on env.sh having been run.

In addition, note that in example.env, I've moved candig-ingest to the authx modules, because it is reliant on keycloak already having been set up.

To test, log into the docker container:
```
CanDIGv2$ docker exec -it candigv2_candig-ingest_1 /bin/bash
root@1a8b4d5f3032:/ingest_app# export CANDIG_SITE_ADMIN_PASSWORD=<value of your lib/tmp/secrets/keycloak-test-user2-password>
root@1a8b4d5f3032:/ingest_app# export CANDIG_SITE_ADMIN_USER=user2
root@1a8b4d5f3032:/ingest_app# export CLINICAL_DATA_LOCATION=/ingest_app/single_ingest.json 
root@1a8b4d5f3032:/ingest_app# python katsu_ingest.py 
Validating input
Validating the mapped schema...
Validation success.
Beginning ingest
...
```