### PR TITLE
DIG-1321: Update Postgres to 16

### DIFF
--- a/lib/postgres/docker-compose.yml
+++ b/lib/postgres/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.7'
 
 services:
   metadata-db:
-    image: postgres:15-alpine
+    image: postgres:16
     #volumes:
       #- katsu-db:/var/lib/postgresql/data
       #add volume name to lib/{compose,swarm,kubernetes}


### PR DESCRIPTION
# Jira Tickets
[DIG-1321](https://candig.atlassian.net/browse/DIG-1321)

# Description
This updates the Postgres container to 16, Debian, both to be up-to-date and also to unify our containers to mostly use the same OS.

# To test:
- Should just run integration-tests? Unsure if we wanted to go through the effort of checking performance before&after.

[DIG-1321]: https://candig.atlassian.net/browse/DIG-1321?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ