### PR TITLE
[Auto-generated] Submodule Updates for CanDIG/katsu (6649772121)

### DIFF
--- a/lib/katsu/docker-compose.yml
+++ b/lib/katsu/docker-compose.yml
@@ -6,7 +6,6 @@ services:
       context: $PWD/lib/katsu/katsu_service
       args:
         venv_python: "${VENV_PYTHON}"
-        alpine_version: "${ALPINE_VERSION}"
         katsu_env: "dev"
     image: ${DOCKER_REGISTRY}/katsu:${KATSU_VERSION:-latest}
     ports:


### PR DESCRIPTION
PR triggered by update to stable branch on CanDIG/katsu. Commit hash: 8224813daeb313823ec59b9e8bb999a87f86db29

- edit katsu docker-compose to remove alpine
- edit katsu dockerfile to use Python official image

### How to test:
- rebuild katsu (might need to build with no cache)
- test-integration