### PR TITLE
DIG-1171: merge Makefile.authx into Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@
 env ?= .env
 
 include $(env)
-include Makefile.authx
 export $(shell sed 's/=.*//' $(env))
 
 SHELL = bash

--- a/Makefile
+++ b/Makefile
@@ -373,6 +373,18 @@ docker-volumes:
 
 
 #>>>
+# authx, common settings
+# make init-authx
+
+#<<<
+.PHONY: init-authx
+init-authx: mkdir
+	$(MAKE) docker-volumes
+	$(foreach MODULE, $(CANDIG_AUTH_MODULES), $(MAKE) build-$(MODULE);)
+	$(foreach MODULE, $(CANDIG_AUTH_MODULES), $(MAKE) compose-$(MODULE);)
+
+
+#>>>
 # initialize conda environment
 # make init-conda
 

--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,8 @@ build-images: #toil-docker
 build-%:
 	printf "\nOutput of build-$*: \n" >> $(ERRORLOG)
 	echo "    started build-$*" >> $(LOGFILE)
-	source setup_hosts.sh; \
+	source setup_hosts.sh
+	-source lib/$*/$*_preflight.sh 2>&1 | tee -a $(ERRORLOG)
 	DOCKER_BUILDKIT=1 COMPOSE_DOCKER_CLI_BUILD=1 \
 	docker compose -f lib/candigv2/docker-compose.yml -f lib/$*/docker-compose.yml build $(BUILD_OPTS) 2>&1 | tee -a $(ERRORLOG)
 	echo "    finished build-$*" >> $(LOGFILE)
@@ -255,7 +256,6 @@ compose:
 compose-%:
 	printf "\nOutput of compose-$*: \n" >> $(ERRORLOG)
 	echo "    started compose-$*" >> $(LOGFILE)
-	-source lib/$*/$*_preflight.sh 2>&1 | tee -a $(ERRORLOG)
 	source setup_hosts.sh; \
 	docker compose -f lib/candigv2/docker-compose.yml -f lib/$*/docker-compose.yml --compatibility up -d 2>&1 | tee -a $(ERRORLOG)
 	-source lib/$*/$*_setup.sh 2>&1 | tee -a $(ERRORLOG)

--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ clean-%:
 	echo "    started clean-$*"
 	source setup_hosts.sh
 	docker compose -f lib/candigv2/docker-compose.yml -f lib/$*/docker-compose.yml down || true
-	docker volume rm `docker volume ls --filter name=$* -q`
+	-docker volume rm `docker volume ls --filter name=$* -q`
 	rm -Rf lib/$*/tmp
 
 

--- a/Makefile
+++ b/Makefile
@@ -383,8 +383,7 @@ docker-volumes:
 .PHONY: init-authx
 init-authx: mkdir
 	$(MAKE) docker-volumes
-	$(foreach MODULE, $(CANDIG_AUTH_MODULES), $(MAKE) build-$(MODULE);)
-	$(foreach MODULE, $(CANDIG_AUTH_MODULES), $(MAKE) compose-$(MODULE);)
+	$(foreach MODULE, $(CANDIG_AUTH_MODULES), $(MAKE) build-$(MODULE); $(MAKE) compose-$(MODULE);)
 
 
 #>>>

--- a/Makefile
+++ b/Makefile
@@ -142,6 +142,19 @@ build-%:
 
 
 #>>>
+# clean target: remove container, volumes, tempfiles
+# make clean-%
+
+#<<<
+clean-%:
+	echo "    started clean-$*"
+	source setup_hosts.sh
+	docker compose -f lib/candigv2/docker-compose.yml -f lib/$*/docker-compose.yml down || true
+	docker volume rm `docker volume ls --filter name=$* -q`
+	rm -Rf lib/$*/tmp
+
+
+#>>>
 # run all cleanup functions
 # WARNING: these are distructive steps, read through instructions before using
 # make clean-all
@@ -150,8 +163,18 @@ build-%:
 .PHONY: clean-all
 clean-all: clean-logs clean-authx clean-compose clean-containers clean-secrets \
 	clean-volumes clean-images clean-bin
-	
-	
+
+
+#>>>
+# close all authentication and authorization services
+# make clean-authx
+
+#<<<
+.PHONY: clean-authx
+clean-authx:
+	$(foreach MODULE, $(CANDIG_AUTH_MODULES), $(MAKE) clean-$(MODULE);)
+
+
 # Empties error and progress logs
 .PHONY: clean-logs
 clean-logs:

--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,9 @@ build-%:
 	printf "\nOutput of build-$*: \n" >> $(ERRORLOG)
 	echo "    started build-$*" >> $(LOGFILE)
 	source setup_hosts.sh
-	-source lib/$*/$*_preflight.sh 2>&1 | tee -a $(ERRORLOG)
+	if [ -f lib/$*/$*_preflight.sh ]; then \
+	source lib/$*/$*_preflight.sh 2>&1 | tee -a $(ERRORLOG); \
+	fi
 	DOCKER_BUILDKIT=1 COMPOSE_DOCKER_CLI_BUILD=1 \
 	docker compose -f lib/candigv2/docker-compose.yml -f lib/$*/docker-compose.yml build $(BUILD_OPTS) 2>&1 | tee -a $(ERRORLOG)
 	echo "    finished build-$*" >> $(LOGFILE)
@@ -280,7 +282,9 @@ compose-%:
 	echo "    started compose-$*" >> $(LOGFILE)
 	source setup_hosts.sh; \
 	docker compose -f lib/candigv2/docker-compose.yml -f lib/$*/docker-compose.yml --compatibility up -d 2>&1 | tee -a $(ERRORLOG)
-	-source lib/$*/$*_setup.sh 2>&1 | tee -a $(ERRORLOG)
+	if [ -f lib/$*/$*_setup.sh ]; then \
+	source lib/$*/$*_setup.sh 2>&1 | tee -a $(ERRORLOG); \
+	fi
 	echo "    finished compose-$*" >> $(LOGFILE)
 
 

--- a/Makefile.authx
+++ b/Makefile.authx
@@ -102,14 +102,3 @@ redeploy-tyk: mkdir
 	$(MAKE) clean-tyk
 	$(MAKE) docker-volumes
 	$(MAKE) compose-tyk
-
-
-#>>>
-# run setup script for service (if available)
-# SERVICE=keycloak
-# make setup-$SERVICE
-
-#<<<
-setup-%:
-	echo "Setting up $*"
-	source lib/$*/$*_setup.sh

--- a/Makefile.authx
+++ b/Makefile.authx
@@ -1,9 +1,0 @@
-#>>>
-# authx, common settings
-# make init-authx
-
-#<<<
-init-authx: mkdir
-	$(MAKE) docker-volumes
-	$(foreach MODULE, $(CANDIG_AUTH_MODULES), $(MAKE) build-$(MODULE);)
-	$(foreach MODULE, $(CANDIG_AUTH_MODULES), $(MAKE) compose-$(MODULE);)

--- a/Makefile.authx
+++ b/Makefile.authx
@@ -1,77 +1,14 @@
 #>>>
-# close keycloak services
-# make clean-keycloak
+# clean target: remove container, volumes, tempfiles
+# make clean-%
 
 #<<<
-clean-keycloak:
-	source setup_hosts.sh; \
-	docker compose -f lib/candigv2/docker-compose.yml -f lib/keycloak/docker-compose.yml down || true
-
-	# - remove intermittent docker images
-	@eval docker images --format '{{.Repository}}:{{.Tag}}' | grep 'keycloak' | xargs -I{} docker rmi --force {}
-
-	-docker volume rm keycloak-data
-
-#>>>
-# close vault services
-# make clean-vault
-
-#<<<
-clean-vault:
-	source setup_hosts.sh; \
-	docker compose -f lib/candigv2/docker-compose.yml -f lib/vault/docker-compose.yml down || true
-
-	# - remove intermittent docker images
-	@eval docker images --format '{{.Repository}}:{{.Tag}}' | grep 'vault' | xargs -I{} docker rmi --force {}
-
-	-docker volume rm vault-data
-
-
-#>>>
-# close opa services
-# make clean-opa
-
-#<<<
-clean-opa:
-	source setup_hosts.sh; \
-	docker compose -f lib/candigv2/docker-compose.yml -f lib/opa/docker-compose.yml down || true
-
-	# - remove intermittent docker images
-	@eval docker images --format '{{.Repository}}:{{.Tag}}' | grep 'openpolicyagent/opa' | xargs -I{} docker rmi --force {}
-	@eval docker images --format '{{.Repository}}:{{.Tag}}' | grep 'opa-runner' | xargs -I{} docker rmi --force {}
-
-	-docker volume rm opa-data
-
-
-#>>>
-# close tyk services
-# make clean-tyk
-
-#<<<
-clean-tyk:
-	source setup_hosts.sh; \
-	docker compose -f lib/candigv2/docker-compose.yml -f lib/tyk/docker-compose.yml down || true
-
-	# - remove intermittent docker images
-	docker images --format '{{.Repository}}:{{.Tag}}' | grep -E 'tyk|redis' |  xargs -I{} docker rmi --force {}
-
-	# - clean tmp dir inside lib/tyk
-	rm -r lib/tyk/tmp || true
-
-	-docker volume rm tyk-data
-	-docker volume rm tyk-redis-data
-
-
-#>>>
-# close federation service
-# make clean-federation
-#<<<
-clean-federation:
-	source setup_hosts.sh; \
-	docker compose -f lib/candigv2/docker-compose.yml -f lib/federation/docker-compose.yml down || true
-
-	# - remove intermittent docker images
-	docker images --format '{{.Repository}}:{{.Tag}}' | grep -E 'federation' |  xargs -I{} docker rmi --force {}
+clean-%:
+	echo "    started clean-$*"
+	source setup_hosts.sh
+	docker compose -f lib/candigv2/docker-compose.yml -f lib/$*/docker-compose.yml down || true
+	docker volume rm `docker volume ls --filter name=$* -q`
+	rm -Rf lib/$*/tmp
 
 
 #>>>
@@ -79,7 +16,8 @@ clean-federation:
 # make clean-authx
 
 #<<<
-clean-authx: clean-keycloak clean-tyk clean-vault clean-opa clean-federation
+clean-authx:
+	$(foreach MODULE, $(CANDIG_AUTH_MODULES), $(MAKE) clean-$(MODULE);)
 
 
 #>>>

--- a/Makefile.authx
+++ b/Makefile.authx
@@ -1,26 +1,4 @@
 #>>>
-# clean target: remove container, volumes, tempfiles
-# make clean-%
-
-#<<<
-clean-%:
-	echo "    started clean-$*"
-	source setup_hosts.sh
-	docker compose -f lib/candigv2/docker-compose.yml -f lib/$*/docker-compose.yml down || true
-	docker volume rm `docker volume ls --filter name=$* -q`
-	rm -Rf lib/$*/tmp
-
-
-#>>>
-# close all authentication and authorization services
-# make clean-authx
-
-#<<<
-clean-authx:
-	$(foreach MODULE, $(CANDIG_AUTH_MODULES), $(MAKE) clean-$(MODULE);)
-
-
-#>>>
 # authx, common settings
 # make init-authx
 

--- a/Makefile.authx
+++ b/Makefile.authx
@@ -91,14 +91,3 @@ init-authx: mkdir
 	$(MAKE) docker-volumes
 	$(foreach MODULE, $(CANDIG_AUTH_MODULES), $(MAKE) build-$(MODULE);)
 	$(foreach MODULE, $(CANDIG_AUTH_MODULES), $(MAKE) compose-$(MODULE);)
-
-
-#>>>
-# authx, redeploy tyk
-# make redeploy-tyk
-
-#<<<
-redeploy-tyk: mkdir
-	$(MAKE) clean-tyk
-	$(MAKE) docker-volumes
-	$(MAKE) compose-tyk

--- a/etc/env/example.env
+++ b/etc/env/example.env
@@ -3,7 +3,7 @@
 
 # site options
 CANDIG_MODULES=minio postgres htsget katsu candig-data-portal candig-ingest query #drs-server wes-server logging monitoring
-CANDIG_AUTH_MODULES=keycloak tyk opa vault federation
+CANDIG_AUTH_MODULES=keycloak vault tyk opa federation
 
 # options are [<ip_addr>, <url>, host.docker.internal, candig.docker.internal]
 CANDIG_DOMAIN=candig.docker.internal

--- a/etc/env/example.env
+++ b/etc/env/example.env
@@ -2,8 +2,8 @@
 # - - -
 
 # site options
-CANDIG_MODULES=minio postgres htsget katsu candig-data-portal candig-ingest query #drs-server wes-server logging monitoring
-CANDIG_AUTH_MODULES=keycloak vault tyk opa federation
+CANDIG_MODULES=minio postgres htsget katsu candig-data-portal query #drs-server wes-server logging monitoring
+CANDIG_AUTH_MODULES=keycloak vault tyk opa federation candig-ingest
 
 # options are [<ip_addr>, <url>, host.docker.internal, candig.docker.internal]
 CANDIG_DOMAIN=candig.docker.internal

--- a/lib/candig-ingest/docker-compose.yml
+++ b/lib/candig-ingest/docker-compose.yml
@@ -15,8 +15,11 @@ services:
             KEYCLOAK_PUBLIC_URL: "${KEYCLOAK_PUBLIC_URL}"
             CANDIG_URL: "http://${CANDIG_DOMAIN}:5080"
             VAULT_URL: "http://${CANDIG_DOMAIN}:${VAULT_SERVICE_PORT}"
-            CANDIG_CLIENT_ID: "${CANDIG_CLIENT_ID}"
-            CANDIG_CLIENT_SECRET: "${CANDIG_CLIENT_SECRET}"
+            CANDIG_CLIENT_ID: "${KEYCLOAK_CLIENT_ID}"
+            CANDIG_SECRET_FILE: "/run/secrets/keycloak-secret"
             OPA_URL: "${OPA_URL}"
         extra_hosts:
               - "${CANDIG_DOMAIN}:${LOCAL_IP_ADDR}"
+        secrets:
+          - source: keycloak-client-local-candig-secret
+            target: keycloak-secret

--- a/lib/templates/docker-compose.yml
+++ b/lib/templates/docker-compose.yml
@@ -12,8 +12,9 @@ services:
       - "candigv2=template"
     #volumes:
       #- {{service_name}}-data:/data
-      #add volume name to lib/{compose,swarm,kubernetes}
-      #add volume name to docker-volumes in Makefile
+      # volume name must start with the name of the service!
+      # add volume name to lib/candigv2/docker-compose.yml
+      # add volume name to docker-volumes in Makefile
     ports:
       - "${{{service_port}}}:{{service_default_port}}"
     depends_on:

--- a/lib/vault/vault_setup.sh
+++ b/lib/vault/vault_setup.sh
@@ -31,11 +31,15 @@ do
   sleep 1
   docker ps --format "{{.Names}}" | grep vault_1
 done
-sleep 5
+sleep 10
 
 # gather keys and login token
 echo ">> gathering keys"
 stuff=$(docker exec $vault sh -c "vault operator init") # | head -7 | rev | cut -d " " -f1 | rev)
+if [ -z ${stuff} ]; then
+  echo "Vault could not initialize"
+  exit 1
+fi
 echo "found stuff as ${stuff}"
 
 key_1=$(echo -n "${stuff}" | grep 'Unseal Key 1: ' | awk '{print $4}' | sed 's/[^a-zA-Z0-9\.\/\+]//g' | sed -e 's/\(0m\)*$//g' | tr -d '[:space:]')


### PR DESCRIPTION
As per DIG-1171:
* I made a new clean-% target that removes the target-named volumes and shuts down the container(s), as well as removing any temp files.
* The new clean-% target replaces specific authx clean targets. After removing unused targets in Makefile.authx, I could then move all remaining targets into Makefile and delete Makefile.authx.
* I also realized that the preflight script does things that are needed for building the image, so I moved that to build-% instead of compose-%.
* Because so many of the auth targets are dependent on the successful building and composing of the others, I rearranged init-authx so that each module is built and composed in sequence, instead of being all built and then all composed.
* I added some checks in keycloak_setup.sh that are described in 1171. Now if you run `make compose-keycloak` twice, it will quit early the second time with an error.

`make clean-authx` and `make init-authx` should work as before, but you should also be able to `make clean-` any module you want.