### PR TITLE
DIG-1272: Clinical ingest integration tests

### DIFF
--- a/etc/tests/test_integration.py
+++ b/etc/tests/test_integration.py
@@ -445,7 +445,7 @@ def clean_up_program(test_id):
         headers=get_headers(is_admin=True),
     )
     assert (
-        delete_response.status_code == HTTPStatus.NO_CONTENT
+        delete_response.status_code == HTTPStatus.NO_CONTENT or delete_response.status_code == HTTPStatus.NOT_FOUND
     ), f"CLEAN_UP_PROGRAM Expected status code {HTTPStatus.NO_CONTENT}, but got {delete_response.status_code}."
     f" Response content: {delete_response.content}"
 

--- a/etc/tests/test_integration.py
+++ b/etc/tests/test_integration.py
@@ -801,7 +801,7 @@ def test_ingest_permissions():
     clean_up_program("SYNTHETIC-2")
     clean_up_program("TEST_2")
 
-    test_loc = "https://raw.githubusercontent.com/CanDIG/candigv2-ingest/add-tests/tests/single_ingest.json"
+    test_loc = "https://raw.githubusercontent.com/CanDIG/candigv2-ingest/develop/tests/single_ingest.json"
     test_data = requests.get(test_loc).json()
 
     token = get_token(

--- a/etc/tests/test_integration.py
+++ b/etc/tests/test_integration.py
@@ -801,7 +801,7 @@ def test_ingest_permissions():
     clean_up_program("SYNTHETIC-2")
     clean_up_program("TEST_2")
 
-    test_loc = "https://raw.githubusercontent.com/CanDIG/candigv2-ingest/develop/single_ingest.json"
+    test_loc = "https://raw.githubusercontent.com/CanDIG/candigv2-ingest/add-tests/tests/single_ingest.json"
     test_data = requests.get(test_loc).json()
 
     token = get_token(


### PR DESCRIPTION
Pick up changes from https://github.com/CanDIG/candigv2-ingest/pull/16 and rebuild. `make test-integration` should test the clinical ingest of single_ingest.json for both non-admin and admin users.