### PR TITLE
OPA ingest tests

### DIFF
--- a/etc/tests/test_integration.py
+++ b/etc/tests/test_integration.py
@@ -108,6 +108,32 @@ def test_opa_datasets(user, dataset):
     assert dataset in response.json()["result"]
 
 
+## Can we add a dataset to one of the users?
+def test_add_opa_dataset():
+    token = get_token(
+        username=ENV["CANDIG_SITE_ADMIN_USER"],
+        password=ENV["CANDIG_SITE_ADMIN_PASSWORD"],
+    )
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json; charset=utf-8",
+    }
+
+    test_data = {
+        "email": ENV["CANDIG_SITE_ADMIN_USER"] + "@test.ca",
+        "program": "OPA-TEST"
+    }
+
+    response = requests.post(f"{ENV['CANDIG_URL']}/ingest/user-access", headers=headers, json=test_data)
+    # when the user has admin access, they should be allowed
+    print(response.json())
+    assert response.status_code == 200
+
+    test_opa_datasets("CANDIG_SITE_ADMIN", test_data["program"])
+
+    response = requests.delete(f"{ENV['CANDIG_URL']}/ingest/user-access", headers=headers, json=test_data)
+
+
 ## Is the user a site admin?
 def user_admin():
     return [

--- a/etc/tests/test_integration.py
+++ b/etc/tests/test_integration.py
@@ -124,14 +124,16 @@ def test_add_opa_dataset():
         "program": "OPA-TEST"
     }
 
-    response = requests.post(f"{ENV['CANDIG_URL']}/ingest/user-access", headers=headers, json=test_data)
+    response = requests.post(f"{ENV['CANDIG_URL']}/ingest/program/{test_data['program']}/email/{test_data['email']}", headers=headers)
     # when the user has admin access, they should be allowed
     print(response.json())
     assert response.status_code == 200
 
     test_opa_datasets("CANDIG_SITE_ADMIN", test_data["program"])
 
-    response = requests.delete(f"{ENV['CANDIG_URL']}/ingest/user-access", headers=headers, json=test_data)
+    response = requests.delete(f"{ENV['CANDIG_URL']}/ingest/program/{test_data['program']}/email/{test_data['email']}", headers=headers)
+    assert response.status_code == 200
+    assert test_data['program'] not in response.json()["access"]["controlled_access_list"][test_data["email"]]
 
 
 ## Is the user a site admin?


### PR DESCRIPTION
After updates in https://github.com/CanDIG/candigv2-ingest/pull/48, this tests adding/removing a user's access to a dataset.