### PR TITLE
Fix an issue where query's health check was not functioning properly

### DIFF
--- a/lib/query/docker-compose.yml
+++ b/lib/query/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     extra_hosts:
       - "${CANDIG_DOMAIN}:${LOCAL_IP_ADDR}"
     healthcheck:
-      test: [ "CMD", "curl", "http://localhost:${QUERY_PORT}" ]
+      test: [ "CMD", "curl", "http://${CANDIG_DOMAIN}:${QUERY_PORT}/service-info" ]
       interval: 30s
       timeout: 20s
       retries: 3


### PR DESCRIPTION
# Description
This fixes an issue where the health check for query was nonfunctional.

## Before
```
(candig) 15:21 fnguyen@fnguyen-worktop:~/Documents/CanDIGv2$ docker ps -f "name=query"
CONTAINER ID   IMAGE                COMMAND                CREATED         STATUS                   PORTS                                       NAMES
e928063cdd79   candig/query:1.0.0                  "bash entrypoint.sh"     12 minutes ago   Up 12 minutes (unhealthy)   0.0.0.0:1236->3000/tcp, :::1236->3000/tcp                       candigv2_query_1
```

## After
```
(candig) 15:28 fnguyen@fnguyen-worktop:~/Documents/CanDIGv2$ docker ps -f "name=query"
CONTAINER ID   IMAGE                COMMAND                CREATED         STATUS                   PORTS                                       NAMES
18656dbdb4c9   candig/query:1.0.0   "bash entrypoint.sh"   2 minutes ago   Up 2 minutes (healthy)   0.0.0.0:1236->3000/tcp, :::1236->3000/tcp   candigv2_query_1
```