### PR TITLE
DIG-1144: Update to python 3.12

### DIFF
--- a/etc/env/example.env
+++ b/etc/env/example.env
@@ -18,7 +18,7 @@ LOCAL_IP_ADDR=
 # options are [linux, darwin, arm64mac]
 VENV_OS=linux
 VENV_NAME=candig
-VENV_PYTHON=3.10
+VENV_PYTHON=3.12
 VENV_PIP=22.2.2
 
 # docker

--- a/etc/env/example.env
+++ b/etc/env/example.env
@@ -18,8 +18,8 @@ LOCAL_IP_ADDR=
 # options are [linux, darwin, arm64mac]
 VENV_OS=linux
 VENV_NAME=candig
-VENV_PYTHON=3.10
-VENV_PIP=22.2.2
+VENV_PYTHON=3.12
+VENV_PIP=23.3.1
 
 # docker
 DOCKER_NAMESPACE=candig

--- a/lib/htsget/docker-compose.yml
+++ b/lib/htsget/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: $PWD/lib/htsget/htsget_app
       args:
-        venv_python: "${VENV_PYTHON}"
+        venv_python: "3.10" #"${VENV_PYTHON}"
     image: ${DOCKER_REGISTRY}/htsget:${HTSGET_VERSION:-latest}
     labels:
       - "candigv2=htsget"


### PR DESCRIPTION
All modules except for htsget should be able to move to 3.12 (and pip to 23.3.1). 