### PR TITLE
DIG-1481: Add an option to keep integration test data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -523,7 +523,11 @@ print-%:
 .PHONY: test-integration
 test-integration:
 	python ./settings.py
-	source ./env.sh; pytest ./etc/tests
+ifeq ($(KEEP_TEST_DATA),true)
+	source ./env.sh; pytest ./etc/tests -k 'not test_clean_up'
+else
+	source ./env.sh; pytest ./etc/tests $(ARGS)
+endif
 
 # stop all docker containers
 .PHONY: stop-all

--- a/etc/env/example.env
+++ b/etc/env/example.env
@@ -13,6 +13,9 @@ CANDIG_SITE_LOCATION=UHN
 CANDIG_DEBUG_MODE=1
 CANDIG_VERSION=v3.0.0
 
+# Uncomment the next line to have the integration tests keep all test data
+#KEEP_TEST_DATA=true
+
 # set this to your local IP address (i.e. 192.168.x.x on most networks) if `make init-authx` cannot automatically determine your IP
 LOCAL_IP_ADDR=
 


### PR DESCRIPTION
# Related Ticket

- [DIG-1481](https://candig.atlassian.net/browse/DIG-1481)

# Description
This allows users to keep integration test data if they set it in either the command line or as a variable in the .env file. The two methods are:
1. Uncomment the line KEEP_TEST_DATA=true
2. Run integration tests with `make test-integration KEEP_TEST_DATA=true`

In addition, I've added an argument ARGS, in case you want more fine-tuned control over your pytest settings (e.g. running specific tests with `make test-integration ARGS="-k 'test_query_discovery'"`

[DIG-1481]: https://candig.atlassian.net/browse/DIG-1481?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ