### PR TITLE
hotfix: set KEEP_TEST_DATA to false by default

### DIFF
--- a/etc/env/example.env
+++ b/etc/env/example.env
@@ -13,8 +13,8 @@ CANDIG_SITE_LOCATION=UHN
 CANDIG_DEBUG_MODE=1
 CANDIG_VERSION=v3.0.0
 
-# Uncomment the next line to have the integration tests keep all test data
-#KEEP_TEST_DATA=true
+# Set KEEP_TEST_DATA to true to have the integration tests keep all test data
+KEEP_TEST_DATA=false
 
 # set this to your local IP address (i.e. 192.168.x.x on most networks) if `make init-authx` cannot automatically determine your IP
 LOCAL_IP_ADDR=


### PR DESCRIPTION
Switch the setting in your .env back and forth to true/false. If it's true, you'll get:
```
$ make test-integration
python ./settings.py
source ./env.sh; pytest ./etc/tests -k 'not test_clean_up'
```

If it's false, you'll get:
```
$ make test-integration
python ./settings.py
source ./env.sh; pytest ./etc/tests 
```