### PR TITLE
DIG-1520: env changes for Opa PR #51

### DIFF
--- a/etc/env/example.env
+++ b/etc/env/example.env
@@ -13,6 +13,9 @@ CANDIG_SITE_LOCATION=UHN
 CANDIG_DEBUG_MODE=1
 CANDIG_VERSION=v3.0.0
 
+# this is the unique key used by your site IDP to identify users.
+CANDIG_USER_KEY=email
+
 # Uncomment the next line to have the integration tests keep all test data
 #KEEP_TEST_DATA=true
 

--- a/etc/tests/test_integration.py
+++ b/etc/tests/test_integration.py
@@ -178,7 +178,7 @@ def test_site_admin(user, is_admin):
     assert ("result" in response.json()) == is_admin
 
 
-## Vault tests: can we add an aws access key and retrieve it, using both the site_admin user and the VAULT_S3_TOKEN?
+## Vault tests: can we add an aws access key and retrieve it?
 def test_vault():
     site_admin_token = get_token(
         username=ENV["CANDIG_SITE_ADMIN_USER"],
@@ -189,15 +189,8 @@ def test_vault():
         "Content-Type": "application/json; charset=utf-8",
     }
 
-    # log in site_admin
-    payload = {"jwt": site_admin_token, "role": "site_admin"}
-    response = requests.post(
-        f"{ENV['CANDIG_URL']}/vault/v1/auth/jwt/login", json=payload, headers=headers
-    )
-    assert "auth" in response.json()
-    client_token = response.json()["auth"]["client_token"]
-
-    headers["X-Vault-Token"] = client_token
+    # confirm that this works with the CANDIG_S3_TOKEN:
+    headers["X-Vault-Token"] = ENV["VAULT_S3_TOKEN"]
     # delete the test secret, if it exists:
     response = requests.delete(
         f"{ENV['CANDIG_URL']}/vault/v1/aws/test-test", headers=headers
@@ -212,8 +205,6 @@ def test_vault():
     print(response.json())
     assert response.status_code == 404
 
-    # confirm that this works with the CANDIG_S3_TOKEN too:
-    headers["X-Vault-Token"] = ENV["VAULT_S3_TOKEN"]
     response = requests.get(
         f"{ENV['CANDIG_URL']}/vault/v1/aws/test-test", headers=headers
     )

--- a/lib/opa/docker-compose.yml
+++ b/lib/opa/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       - source: keycloak-test-user2-password
         target: /run/secrets/password
     environment:
-      KEYCLOAK_PUBLIC_URL: "${KEYCLOAK_PUBLIC_URL}"
+      KEYCLOAK_PUBLIC_URL: ${KEYCLOAK_PUBLIC_URL}
       KEYCLOAK_CLIENT_ID: ${KEYCLOAK_CLIENT_ID}
       KEYCLOAK_REALM_URL: ${KEYCLOAK_REALM_URL}
       KEYCLOAK_URL: ${KEYCLOAK_PRIVATE_URL}
@@ -34,6 +34,7 @@ services:
       OPA_URL: ${OPA_PRIVATE_URL}
       VAULT_URL: ${VAULT_PRIVATE_URL}
       SERVICE_NAME: ${SERVICE_NAME}
+      CANDIG_USER_KEY: ${CANDIG_USER_KEY}
     healthcheck:
       test: [ "CMD", "python", "/app/healthcheck.py"]
       interval: 30s

--- a/lib/tyk/configuration_templates/api_candig.json.tpl
+++ b/lib/tyk/configuration_templates/api_candig.json.tpl
@@ -61,11 +61,6 @@
             }
             ],
         "post": [
-            {
-                "name": "permissionsStoreMiddleware",
-                "path": "/opt/tyk-gateway/middleware/permissionsStoreMiddleware.js",
-                "require_session": false
-            }
         ],
         "id_extractor": {
             "extract_with": "",

--- a/lib/tyk/configuration_templates/api_graphql.json.tpl
+++ b/lib/tyk/configuration_templates/api_graphql.json.tpl
@@ -61,11 +61,6 @@
             }
             ],
         "post": [
-            {
-                "name": "permissionsStoreMiddleware",
-                "path": "/opt/tyk-gateway/middleware/permissionsStoreMiddleware.js",
-                "require_session": false
-            }
         ],
         "id_extractor": {
             "extract_with": "",

--- a/lib/tyk/configuration_templates/api_mcode_candig_data_portal.json.tpl
+++ b/lib/tyk/configuration_templates/api_mcode_candig_data_portal.json.tpl
@@ -61,11 +61,6 @@
             }
             ],
         "post": [
-            {
-                "name": "permissionsStoreMiddleware",
-                "path": "/opt/tyk-gateway/middleware/permissionsStoreMiddleware.js",
-                "require_session": false
-            }
         ],
         "id_extractor": {
             "extract_with": "",

--- a/lib/tyk/configuration_templates/api_opa.json.tpl
+++ b/lib/tyk/configuration_templates/api_opa.json.tpl
@@ -61,11 +61,6 @@
             }
             ],
         "post": [
-            {
-                "name": "permissionsStoreMiddleware",
-                "path": "/opt/tyk-gateway/middleware/permissionsStoreMiddleware.js",
-                "require_session": false
-            }
         ],
         "id_extractor": {
             "extract_with": "",

--- a/lib/tyk/configuration_templates/api_template.json.tpl
+++ b/lib/tyk/configuration_templates/api_template.json.tpl
@@ -61,11 +61,6 @@
             }
             ],
         "post": [
-            {
-                "name": "permissionsStoreMiddleware",
-                "path": "/opt/tyk-gateway/middleware/permissionsStoreMiddleware.js",
-                "require_session": false
-            }
         ],
         "id_extractor": {
             "extract_with": "",

--- a/lib/vault/vault_setup.sh
+++ b/lib/vault/vault_setup.sh
@@ -94,20 +94,10 @@ echo
 echo ">> enabling audit file"
 docker exec $vault sh -c "vault audit enable file file_path=/vault/vault-audit.log"
 
-# enable jwt
-echo
-echo ">> enabling jwt"
-docker exec $vault sh -c "vault auth enable jwt"
-
 # enable approle
 echo
 echo ">> enabling approle"
 docker exec $vault sh -c "vault auth enable approle"
-
-# tyk policy
-echo
-echo ">> setting up tyk user-claims policy"
-docker exec $vault sh -c "echo 'path \"identity/oidc/token/*\" {capabilities = [\"create\", \"read\"]}' > tyk-claims-policy.hcl; vault policy write tyk-claims tyk-claims-policy.hcl"
 
 echo
 echo ">> setting up aws policy"
@@ -146,81 +136,6 @@ docker exec $vault sh -c "echo 'path \"opa/access\" {capabilities = [\"update\",
 
 # Federation needs access to the opa store's data path (to add servers):
 docker exec $vault sh -c "echo 'path \"opa/data\" {capabilities = [\"update\", \"read\", \"delete\"]}' >> federation-policy.hcl; vault policy write federation federation-policy.hcl"
-
-# user claims
-echo
-echo ">> setting up user claims"
-docker exec $vault sh -c "vault write auth/jwt/role/researcher user_claim=preferred_username bound_audiences=${KEYCLOAK_CLIENT_ID} role_type=jwt policies=tyk-claims ttl=1h"
-
-# site admin should always be able to access aws secrets
-docker exec $vault sh -c "vault write auth/jwt/role/site_admin user_claim=site_admin bound_audiences=${KEYCLOAK_CLIENT_ID} role_type=jwt policies=aws ttl=1h"
-
-# configure jwt
-echo
-echo ">> configuring jwt stuff"
-docker exec $vault sh -c "vault write auth/jwt/config oidc_discovery_url=\"${KEYCLOAK_PUBLIC_URL}/auth/realms/candig\" bound_issuer=\"${KEYCLOAK_PUBLIC_URL}/auth/realms/candig\" default_role=\"researcher\""
-
-# create users
-echo
-KEYCLOAK_TEST_USER="$(cat tmp/secrets/keycloak-test-user)"
-echo ">> creating user $KEYCLOAK_TEST_USER"
-export TEMPLATE_DATASET_PERMISSIONS=4
-TEST_USER_PERMISSIONS_DATASTRUCTURE=$(envsubst < lib/vault/configuration_templates/vault-entity-entitlements.json.tpl)
-
-test_user_output=$(docker exec $vault sh -c "echo '${TEST_USER_PERMISSIONS_DATASTRUCTURE}' > ${KEYCLOAK_TEST_USER}.json; vault write identity/entity @${KEYCLOAK_TEST_USER}.json; rm ${KEYCLOAK_TEST_USER}.json;")
-
-ENTITY_ID=$(echo "${test_user_output}" | grep id | awk '{print $2}')
-echo ">>> found entity id : ${ENTITY_ID}"
-
-
-KEYCLOAK_TEST_USER_TWO="$(cat tmp/secrets/keycloak-test-user2)"
-echo ">> creating user $KEYCLOAK_TEST_USER_TWO"
-export TEMPLATE_DATASET_PERMISSIONS=1
-TEST_USER_TWO_PERMISSIONS_DATASTRUCTURE=$(envsubst < lib/vault/configuration_templates/vault-entity-entitlements.json.tpl)
-
-test_user_output_two=$(docker exec $vault sh -c "echo '${TEST_USER_TWO_PERMISSIONS_DATASTRUCTURE}' > ${KEYCLOAK_TEST_USER_TWO}.json; vault write identity/entity @${KEYCLOAK_TEST_USER_TWO}.json; rm ${KEYCLOAK_TEST_USER_TWO}.json;")
-
-ENTITY_ID_TWO=$(echo "${test_user_output_two}" | grep id | awk '{print $2}')
-echo ">>> found entity id 2: ${ENTITY_ID_TWO}"
-
-
-
-# setup aliases
-echo
-echo ">> setting up alias for $KEYCLOAK_TEST_USER"
-AUTH_LIST_OUTPUT=$(docker exec $vault sh -c "vault auth list -format=json")
-
-JWT_ACCESSOR_VALUE=$(echo "${AUTH_LIST_OUTPUT}" | grep accessor | head -1 | awk '{print $2}' | tr -d '"' | tr -d ',' | tr -d '[:space:]')
-echo ">>> found jwt accessor : ${JWT_ACCESSOR_VALUE}"
-
-echo
-echo ">> writing alias"
-# echo "using ${KEYCLOAK_TEST_USER}"
-# echo "using ${JWT_ACCESSOR_VALUE}"
-# echo "using ${ENTITY_ID}"
-STRUCTURE="{\\\"name\\\":\\\"${KEYCLOAK_TEST_USER}\\\",\\\"mount_accessor\\\":\\\"${JWT_ACCESSOR_VALUE}\\\",\\\"canonical_id\\\":\\\"${ENTITY_ID}\\\"}"
-docker exec $vault sh -c "echo ${STRUCTURE} | tr -d '[:space:]' > alias.json; echo 'catting alias.json'; cat alias.json ; vault write identity/entity-alias @alias.json;" # rm alias.json;"
-
-STRUCTURE="{\\\"name\\\":\\\"${KEYCLOAK_TEST_USER_TWO}\\\",\\\"mount_accessor\\\":\\\"${JWT_ACCESSOR_VALUE}\\\",\\\"canonical_id\\\":\\\"${ENTITY_ID_TWO}\\\"}"
-docker exec $vault sh -c "echo ${STRUCTURE} | tr -d '[:space:]' > alias.json; echo 'catting alias.json'; cat alias.json ; vault write identity/entity-alias @alias.json;" # rm alias.json;"
-
-
-# enable identity tokens
-echo
-echo ">> enabling identity tokens"
-docker exec $vault sh -c "echo '{\"rotation_period\":\"24h\",\"allowed_client_ids\":[\"${KEYCLOAK_CLIENT_ID}\"]}' > test-key.json; vault write identity/oidc/key/test-key @test-key.json; rm test-key.json;"
-echo
-
-
-# match key and insert custom info into the jwt
-echo
-echo ">> matching key and inserting custom info into the jwt"
-# vault-datastructure.json.tpl has the template parameter which is supposed to be
-# json escaped or base64 escaped string and the braces have to be spaced apart
-# because templating code requres {{}} which when followed by another brace
-# messes up Vault and it complains that there is a mismatch in balance of braces
-VAULT_IDENTITY_ROLE_TEMPLATE=$(envsubst < lib/vault/configuration_templates/vault-datastructure.json.tpl)
-docker exec $vault sh -c "echo '${VAULT_IDENTITY_ROLE_TEMPLATE}' > researcher.json; vault write identity/oidc/role/researcher @researcher.json; rm researcher.json;"
 
 vault_runner=$(docker ps -a --format "{{.Names}}" | grep vault-runner_1 | awk '{print $1}')
 docker restart $vault_runner


### PR DESCRIPTION
Creates the CANDIG_USER_KEY and passes it to the Opa microservice. This key allows the site to adjust the unique identifier used in their IDP's jwts, in case they don't use email (or name it differently).

This picks up https://github.com/CanDIG/candig-opa/pull/51.