### PR TITLE
Fix make clean-*

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ clean-%:
 	export SERVICE_NAME=$*; \
 	docker compose -f lib/candigv2/docker-compose.yml -f lib/$*/docker-compose.yml down || true
 	-docker volume rm `docker volume ls --filter name=$* -q`
-	docker image rm `docker image ls --format "{{.Repository}}" | grep $*`
+	docker image rm `docker image ls --format "{{.Repository}}:{{.Tag}}" | grep $*`
 	rm -Rf lib/$*/tmp
 
 


### PR DESCRIPTION
Found that make clean was not working for individual services and discovered the tag needed to be incorporated to delete properly. Maybe a docker versioning thing? Would be good to have others test whether this fix works for them too.

