### PR TITLE
Fix the CIDR 16-bit subnet mask replacement with a general-purpose one

### DIFF
--- a/create_service_store.sh
+++ b/create_service_store.sh
@@ -61,7 +61,7 @@ create_service_store() {
         done
         # if we're not in debug mode, delete the tmp roleid file
         if [[ ${CANDIG_DEBUG_MODE:-"0"} == "0" ]]; then
-            rm $PWD/tmp/vault/{service}-roleid
+            rm $PWD/tmp/vault/${service}-roleid
         fi
 
     done

--- a/create_service_store.sh
+++ b/create_service_store.sh
@@ -83,7 +83,7 @@ collect_ips() {
             do
                 container=$(echo ${container} | tr -d "'")
                 local ip=$(echo $network_containers | jq --arg x "candigv2_${container}_1" -r '.[$x]')
-                ip="${ip%16}32"
+                ip="${ip%/*}/32"
                 ips+="\"$ip\","
             done
         fi


### PR DESCRIPTION
Vault service store creation fails when the docker container's IP address's subnet mask is not 16 bits wide.

Example:
```
create an approle for opa
Error writing data to auth/approle/role/opa: Error making API request.

URL: PUT http://127.0.0.1:8200/v1/auth/approle/role/opa
Code: 500. Errors:

* 1 error occurred:
	* failed to validate CIDR blocks: invalid CIDR address: 192.168.48.13/2032
```
Here, a substitution for /20 failed, and it ended up as a 2032 bit sized block.