### PR TITLE
Hotfix: Fix check for errors in test_ingest_htsget

### DIFF
--- a/etc/tests/test_integration.py
+++ b/etc/tests/test_integration.py
@@ -461,7 +461,7 @@ def test_ingest_htsget():
     for id in response.json()["results"]:
         assert "genomic" in response.json()["results"][id]
         assert "sample" in response.json()["results"][id]
-        assert "errors" not in response.json()
+        assert len(response.json()["errors"]) == 0
 
 
 def test_sample_metadata():


### PR DESCRIPTION
We decided to always leave the "errors" key in the dict, even if it's empty.