### PR TITLE
DIG-1275: modifying site roles

### DIFF
--- a/etc/tests/test_integration.py
+++ b/etc/tests/test_integration.py
@@ -198,6 +198,35 @@ def test_site_admin(user, is_admin):
     assert ("result" in response.json()) == is_admin
 
 
+def test_add_remove_site_admin():
+    token = get_token(
+        username=ENV["CANDIG_SITE_ADMIN_USER"],
+        password=ENV["CANDIG_SITE_ADMIN_PASSWORD"],
+    )
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json; charset=utf-8",
+    }
+
+    # add user1 to site admins
+    response = requests.post(
+        f"{ENV['CANDIG_URL']}/ingest/site-role/site_admin/email/{ENV['CANDIG_NOT_ADMIN_USER']}@test.ca",
+        headers=headers
+    )
+    print(response.text)
+    assert response.status_code == 200
+
+    test_site_admin("CANDIG_NOT_ADMIN", True)
+
+    # remove user1 from site admins
+    response = requests.delete(
+        f"{ENV['CANDIG_URL']}/ingest/site-role/site_admin/email/{ENV['CANDIG_NOT_ADMIN_USER']}@test.ca",
+        headers=headers
+    )
+    assert response.status_code == 200
+
+
+
 ## Vault tests: can we add an aws access key and retrieve it?
 def test_vault():
     site_admin_token = get_token(

--- a/etc/tests/test_integration.py
+++ b/etc/tests/test_integration.py
@@ -140,6 +140,10 @@ def test_add_remove_opa_dataset():
     print(response.text)
     assert response.status_code < 300
 
+    # if the site user is the default user, there should be a warning
+    if ENV['CANDIG_SITE_ADMIN_USER'] == 'user2':
+        assert "warning" in response.json()
+
     # try adding a user to the program:
     test_data = {
         "email": ENV["CANDIG_NOT_ADMIN_USER"] + "@test.ca",

--- a/lib/candig-ingest/docker-compose.yml
+++ b/lib/candig-ingest/docker-compose.yml
@@ -21,6 +21,7 @@ services:
             CANDIG_SECRET_FILE: "/run/secrets/keycloak-secret"
             OPA_URL: ${OPA_PRIVATE_URL}
             SERVICE_NAME: "${SERVICE_NAME}"
+            DEFAULT_SITE_ADMIN_USER: ${CANDIG_SITE_ADMIN_USER}
         extra_hosts:
               - "${CANDIG_DOMAIN}:${LOCAL_IP_ADDR}"
         secrets:

--- a/lib/vault/vault_setup.sh
+++ b/lib/vault/vault_setup.sh
@@ -132,7 +132,7 @@ rm lib/vault/tmp/temp.json
 
 ## SPECIAL STORES ACCESS
 # Ingest needs access to the opa store's programs path:
-docker exec $vault sh -c "echo 'path \"opa/programs\" {capabilities = [\"update\", \"read\"]}' >> ${ingest}-policy.hcl; echo 'path \"opa/programs/*\" {capabilities = [\"create\", \"update\", \"read\", \"delete\"]}' >> ${ingest}-policy.hcl; vault policy write ${ingest} ${ingest}-policy.hcl"
+docker exec $vault sh -c "echo 'path \"opa/programs\" {capabilities = [\"update\", \"read\"]}' >> ${ingest}-policy.hcl; echo 'path \"opa/programs/*\" {capabilities = [\"create\", \"update\", \"read\", \"delete\"]}' >> ${ingest}-policy.hcl; echo 'path \"opa/roles\" {capabilities = [\"create\", \"update\", \"read\", \"delete\"]}' >> ${ingest}-policy.hcl; vault policy write ${ingest} ${ingest}-policy.hcl"
 
 # Federation needs access to the opa store's data path (to add servers):
 docker exec $vault sh -c "echo 'path \"opa/data\" {capabilities = [\"update\", \"read\", \"delete\"]}' >> federation-policy.hcl; vault policy write federation federation-policy.hcl"


### PR DESCRIPTION
Picks up changes in https://github.com/CanDIG/candigv2-ingest/pull/86 and the matching permissions changes needed for vault-setup and ingest's docker-compose. Also implements tests for roles.