### PR TITLE
Increase healthcheck timeout for metadata-db, and fix the healthcheck.

### DIFF
--- a/lib/postgres/docker-compose.yml
+++ b/lib/postgres/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     labels:
       - "candigv2=chord-metadata"
     healthcheck:
-      test: ["CMD", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      test: /usr/bin/pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB
       interval: 60s
       timeout: 3s
       retries: 3

--- a/lib/postgres/docker-compose.yml
+++ b/lib/postgres/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     labels:
       - "candigv2=chord-metadata"
     healthcheck:
-      test: /usr/bin/pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB
+      test: export PGPASSWORD=$(< $$POSTGRES_PASSWORD_FILE); psql -d $$POSTGRES_DB -U $$POSTGRES_USER -c "SELECT 1"
       interval: 60s
       timeout: 3s
       retries: 3

--- a/lib/postgres/docker-compose.yml
+++ b/lib/postgres/docker-compose.yml
@@ -24,8 +24,8 @@ services:
     labels:
       - "candigv2=chord-metadata"
     healthcheck:
-      test: ["CMD-SHELL", "sh -c 'pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}'"]
-      interval: 10s
+      test: ["CMD", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      interval: 60s
       timeout: 3s
       retries: 3
 


### PR DESCRIPTION
# Ticket(s)
[DIG-1571](https://candig.atlassian.net/browse/DIG-1571)

# Description
This both fixes the command being used to check metadata-db, and increases the timeout for it

# To test
1. Check that metadata-db still runs, and that the healthcheck reports healthy initially.
2. `docker exec -it candigv2_katsu_1 bash`
3. `export PGPASSWORD=$(< /run/secrets/metadata_db_secret)`
4. `psql -h metadata-db -U "admin" -d genomic`
5. `DROP DATABASE metadata;`
6. Exit out. Healthcheck should now be "unhealthy"

[DIG-1571]: https://candig.atlassian.net/browse/DIG-1571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ