### PR TITLE
Fix nightly_env.sh not getting run after git pull

### DIFF
--- a/nightly_build.sh
+++ b/nightly_build.sh
@@ -89,5 +89,5 @@ pip install openapi_spec_validator
 python katsu_ingest.py
 cd $BUILD_PATH
 
-PostToSlack "\`\`\`Build success:\nhttp://candig-dev.hpc4healthlocal:5080/\nusername: user2@test.ca\npassword $(cat ./tmp/secrets/keycloak-test-user2-password)\`\`\`"
+PostToSlack "\`\`\`Build success:\nhttp://candig-dev.hpc4healthlocal:5080/\nusername: $(cat ./tmp/secrets/keycloak-test-user2)\npassword $(cat ./tmp/secrets/keycloak-test-user2-password)\`\`\`"
 

--- a/nightly_build.sh
+++ b/nightly_build.sh
@@ -89,5 +89,5 @@ pip install openapi_spec_validator
 python katsu_ingest.py
 cd $BUILD_PATH
 
-PostToSlack "\`\`\`Build success:\nhttp://candig-dev.hpc4healthlocal:5080/\nusername: $(cat ./tmp/secrets/keycloak-test-user2)\npassword $(cat ./tmp/secrets/keycloak-test-user2-password)\`\`\`"
+PostToSlack "\`\`\`Build success:\nhttp://candig-dev.hpc4healthlocal:5080/\nusername: $(cat ./tmp/secrets/keycloak-test-site-admin)\npassword $(cat ./tmp/secrets/keycloak-test-site-admin-password)\`\`\`"
 

--- a/nightly_build.sh
+++ b/nightly_build.sh
@@ -43,6 +43,9 @@ if [[ $SKIP_GIT -ne 1 ]]; then
     fi
 fi
 
+# Rerun nightly_env.sh in case anything changed in the .env file
+source nightly_env.sh
+
 # Re-initialize conda
 make bin-conda
 source bin/miniconda3/etc/profile.d/conda.sh
@@ -86,5 +89,5 @@ pip install openapi_spec_validator
 python katsu_ingest.py
 cd $BUILD_PATH
 
-PostToSlack "\`\`\`Build success:\nhttp://candig-dev.hpc4healthlocal:5080/\nusername: user2\npassword $(cat ./tmp/secrets/keycloak-test-user2-password)\`\`\`"
+PostToSlack "\`\`\`Build success:\nhttp://candig-dev.hpc4healthlocal:5080/\nusername: user2@test.ca\npassword $(cat ./tmp/secrets/keycloak-test-user2-password)\`\`\`"
 


### PR DESCRIPTION
# Description
`nightly_env.sh`, which is responsible for copying over the .env file and replacing its contents with site-specific information, was run *before* running `git pull`, which is partially expected behaviour (the controls for whether or not `git pull` is run at all is in there) but also means that it won't pull the latest version of the `.env` file. This fixes that by re-running nightly_env.sh after `git pull`.

Also while I was at it I updated the username to match what the actual username is now.