### PR TITLE
hotfix: now that awscli requirement is loosened, should be able to install requirements

### DIFF
--- a/nightly_build.sh
+++ b/nightly_build.sh
@@ -84,8 +84,7 @@ source env.sh
 cd $INGEST_PATH
 export CLINICAL_DATA_LOCATION=$INGEST_PATH/tests/clinical_ingest.json
 # should be pip install -r requirements.txt, but that didn't seem to work last I checked -- dependency errors?
-pip install dateparser
-pip install openapi_spec_validator
+pip install -r requirements.txt
 python katsu_ingest.py
 cd $BUILD_PATH
 


### PR DESCRIPTION
requirements in ingest were updated in https://github.com/CanDIG/candigv2-ingest/pull/86