### PR TITLE
DIG-1243: Set up and configure Redis independent from tyk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -358,6 +358,8 @@ docker-secrets: mkdir minio-secrets katsu-secrets
 	$(MAKE) secret-opa-root-token
 	$(MAKE) secret-opa-service-token
 
+	$(MAKE) secret-redis-secret-key
+
 
 
 #>>>
@@ -375,7 +377,7 @@ docker-volumes:
 	docker volume create toil-jobstore --label candigv2=volume
 	docker volume create keycloak-data --label candigv2=volume
 	docker volume create tyk-data --label candigv2=volume
-	docker volume create tyk-redis-data --label candigv2=volume
+	docker volume create redis-data --label candigv2=volume
 	docker volume create vault-data --label candigv2=volume
 	docker volume create opa-data --label candigv2=volume
 	docker volume create htsget-data --label candigv2=volume

--- a/etc/env/example.env
+++ b/etc/env/example.env
@@ -2,7 +2,7 @@
 # - - -
 
 # site options
-CANDIG_MODULES=keycloak vault minio postgres htsget katsu candig-data-portal query tyk opa federation candig-ingest
+CANDIG_MODULES=keycloak vault minio postgres htsget katsu query redis tyk opa federation candig-ingest candig-data-portal
     #drs-server wes-server logging monitoring
 CANDIG_AUTH_MODULES=keycloak vault tyk opa
 
@@ -188,9 +188,11 @@ CANDIG_INGEST_VERSION=4.0.0
 CANDIG_INGEST_PORT=1235
 CANDIG_INGEST_PRIVATE_URL=http://candig-ingest:${CANDIG_INGEST_PORT}
 
+# redis
+REDIS_VERSION=6.2.14
+
 # tyk service
 TYK_VERSION=v5.0.10
-TYK_REDIS_VERSION=6.2-alpine
 TYK_SERVICE_PUBLIC_PORT=5080
 TYK_SERVICE_HOST=0.0.0.0
 #TODO: consolidate tyk public and private domains

--- a/lib/candigv2/docker-compose.yml
+++ b/lib/candigv2/docker-compose.yml
@@ -17,7 +17,7 @@ volumes:
     external: true
   tyk-data:
     external: true
-  tyk-redis-data:
+  redis-data:
     external: true
   vault-data:
     external: true
@@ -143,5 +143,9 @@ secrets:
       - "candigv2=secret"
   tyk-secret-key:
     file: $PWD/tmp/secrets/tyk-secret-key
+    labels:
+      - "candigv2=secret"
+  redis-secret-key:
+    file: $PWD/tmp/secrets/redis-secret-key
     labels:
       - "candigv2=secret"

--- a/lib/katsu/docker-compose.prod.yml
+++ b/lib/katsu/docker-compose.prod.yml
@@ -8,7 +8,4 @@ services:
     environment:
       - DJANGO_SETTINGS_MODULE=config.settings.prod
       - CONN_MAX_AGE=60 # change on traffic and performance
-      - UWSGI_WORKERS=4
-  metadata-db:
-    ports:
-      - "5432:5432"
+      - UWSGI_WORKERS=4 # change on cpu cores and performance

--- a/lib/katsu/docker-compose.yml
+++ b/lib/katsu/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - POSTGRES_PORT=5432
       - POSTGRES_USER=admin
       - POSTGRES_PASSWORD_FILE=/run/secrets/metadata_db_secret
+      - REDIS_PASSWORD_FILE=/run/secrets/redis_secret_key
       - OPA_URL=${OPA_PRIVATE_URL}
       - EXTERNAL_URL=${CANDIG_DOMAIN}
       - KATSU_AUTHORIZATION=${CANDIG_AUTHORIZATION}
@@ -25,9 +26,12 @@ services:
       - CONN_MAX_AGE=60
       - DJANGO_SETTINGS_MODULE=config.settings.dev
       - UWSGI_WORKERS=1
+      - CACHE_DURATION=86400
     secrets:
       - source: metadata-db-secret
         target: metadata_db_secret
+      - source: redis-secret-key
+        target: redis_secret_key
       - source: opa-root-token
         target: opa-root-token
       - source: katsu-secret-key

--- a/lib/redis/docker-compose.yml
+++ b/lib/redis/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '3.7'
+
+services:
+  redis:
+    image: redis:${REDIS_VERSION}
+    labels:
+      - "candigv2=redis"
+    volumes:
+      - redis-data:/data
+    ports:
+      - "6379:6379"
+    extra_hosts:
+      - "${CANDIG_DOMAIN}:${LOCAL_IP_ADDR}"
+    secrets:
+      - redis-secret-key
+    environment:
+      - REDIS_PASSWORD_FILE=/run/secrets/redis-secret-key
+    command: sh -c "redis-server --requirepass $(cat $$REDIS_PASSWORD_FILE)"
+    healthcheck:
+      test: redis-cli ping
+      interval: 30s
+      timeout: 20s
+      retries: 3

--- a/lib/tyk/configuration_templates/tyk.conf.tpl
+++ b/lib/tyk/configuration_templates/tyk.conf.tpl
@@ -129,14 +129,14 @@
   "storage": {
     "database": 0,
     "enable_cluster": false,
-    "host": "tyk-redis",
+    "host": "redis",
     "hosts": null,
     "optimisation_max_active": 5000,
     "optimisation_max_idle": 3000,
-    "password": "",
+    "password": "${REDIS_SECRET_KEY}",
     "port": 6379,
     "type": "redis",
-    "username": ""
+    "username": "default"
   },
   "suppress_default_org_store": false,
   "suppress_redis_signal_reload": false,

--- a/lib/tyk/docker-compose.yml
+++ b/lib/tyk/docker-compose.yml
@@ -12,28 +12,10 @@ services:
       - "${TYK_SERVICE_PUBLIC_PORT}:8080"
     volumes:
       - tyk-data:/opt/tyk-gateway
-    depends_on:
-      - tyk-redis
     extra_hosts:
       - "${CANDIG_DOMAIN}:${LOCAL_IP_ADDR}"
     healthcheck:
       test: [ "CMD", "curl", "http://0.0.0.0:8080/hello" ]
-      interval: 30s
-      timeout: 20s
-      retries: 3
-
-  tyk-redis:
-    image: redis:${TYK_REDIS_VERSION}
-    labels:
-      - "candigv2=tyk"
-    volumes:
-      - tyk-redis-data:/data
-    ports:
-      - "6379:6379"
-    extra_hosts:
-      - "${CANDIG_DOMAIN}:${LOCAL_IP_ADDR}"
-    healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
       interval: 30s
       timeout: 20s
       retries: 3

--- a/lib/tyk/tyk_preflight.sh
+++ b/lib/tyk/tyk_preflight.sh
@@ -33,6 +33,9 @@ export TYK_ANALYTIC_ADMIN_SECRET=$TYK_ANALYTIC_ADMIN_SECRET_VAL
 KEYCLOAK_PUBLIC_KEY_VAL=$(cat $PWD/tmp/secrets/keycloak-public-key)
 export KEYCLOAK_PUBLIC_KEY=$KEYCLOAK_PUBLIC_KEY_VAL
 
+REDIS_SECRET_KEY_VAL=$(cat $PWD/tmp/secrets/redis-secret-key)
+export REDIS_SECRET_KEY=$REDIS_SECRET_KEY_VAL
+
 mkdir -p $CONFIG_DIR $CONFIG_DIR/apps $CONFIG_DIR/policies $CONFIG_DIR/middleware
 
 # Copy files from template configs


### PR DESCRIPTION
## What's new
- Redis now has its own module
- Rename volume `tyk-redis-data` to `redis-data`
- Redis now requires a password to login
- Add Redis secret to tyk compose
- Add Redis secret to katsu compose

### How to test
- Rebuild the stack
- Run test-integration