### PR TITLE
DIG-1601: Remove version line from docker-compose files

### DIFF
--- a/lib/candig-data-portal/docker-compose.yml
+++ b/lib/candig-data-portal/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   candig-data-portal:
     labels:

--- a/lib/candig-ingest/docker-compose.yml
+++ b/lib/candig-ingest/docker-compose.yml
@@ -1,5 +1,3 @@
-version: 1.0.1
-
 services:
     candig-ingest:
         build:

--- a/lib/candigv2/docker-compose.yml
+++ b/lib/candigv2/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 volumes:
   minio-data:
     external: true

--- a/lib/federation/docker-compose.yml
+++ b/lib/federation/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   federation:
     build:

--- a/lib/htsget/docker-compose.yml
+++ b/lib/htsget/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   htsget:
     build:

--- a/lib/katsu/docker-compose.prod.yml
+++ b/lib/katsu/docker-compose.prod.yml
@@ -1,10 +1,8 @@
-version: '3.7'
-
 services:
   katsu:
     build:
-        args:
-          katsu_env: "prod"
+      args:
+        katsu_env: "prod"
     environment:
       - DJANGO_SETTINGS_MODULE=config.settings.prod
       - CONN_MAX_AGE=60 # change on traffic and performance

--- a/lib/katsu/docker-compose.yml
+++ b/lib/katsu/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   katsu:
     build:

--- a/lib/keycloak/docker-compose.yml
+++ b/lib/keycloak/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   keycloak:
     image: keycloak/keycloak:${KEYCLOAK_VERSION}

--- a/lib/logging/docker-compose.yml
+++ b/lib/logging/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
 
   fluentd:

--- a/lib/minio/docker-compose.yml
+++ b/lib/minio/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   minio:
     image: minio/minio:${MINIO_VERSION:-latest}

--- a/lib/monitoring/docker-compose.yml
+++ b/lib/monitoring/docker-compose.yml
@@ -1,8 +1,6 @@
 # references:
 # - https://github.com/Einsteinish/Docker-Compose-Prometheus-and-Grafana
 # - https://github.com/vegasbrianc/prometheus/blob/master/prometheus/prometheus.yml
-version: '3.7'
-
 services:
 
   prometheus:

--- a/lib/opa/docker-compose.yml
+++ b/lib/opa/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.7'
 services:
   opa-runner:
     build:

--- a/lib/postgres/docker-compose.yml
+++ b/lib/postgres/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   metadata-db:
     image: postgres:16

--- a/lib/query/docker-compose.yml
+++ b/lib/query/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   query:
     labels:

--- a/lib/redis/docker-compose.yml
+++ b/lib/redis/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   redis:
     image: redis:${REDIS_VERSION}

--- a/lib/templates/docker-compose.yml
+++ b/lib/templates/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   {{service_name}}:
     build:

--- a/lib/toil/docker-compose.yml
+++ b/lib/toil/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   toil-server:
     image: ${DOCKER_REGISTRY}/toil:${TOIL_VERSION:-latest}

--- a/lib/tyk/docker-compose.yml
+++ b/lib/tyk/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   tyk:
     build:

--- a/lib/vault/docker-compose.yml
+++ b/lib/vault/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   vault:
     image: hashicorp/vault:${VAULT_VERSION}

--- a/lib/wes-server/docker-compose.yml
+++ b/lib/wes-server/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   wes-server:
     build:


### PR DESCRIPTION
[Jira ticket](https://candig.atlassian.net/browse/DIG-1601)

This removes the version number from the top of our docker-compose.yml files. This should reduce the number of warnings we get from the full build, without changing anything else.

NB: There's a few other changes in here that my vim auto-added -- it looks like they're just formatting fixes (newline at end of file, tab correction)