### PR TITLE
DIG-1434: Update htsget to Python 3.12

### DIFF
--- a/lib/htsget/docker-compose.yml
+++ b/lib/htsget/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     build:
       context: $PWD/lib/htsget/htsget_app
       args:
-        venv_python: "3.10" #"${VENV_PYTHON}"
+        venv_python: "${VENV_PYTHON}"
     image: ${DOCKER_REGISTRY}/htsget:${HTSGET_VERSION:-latest}
     labels:
       - "candigv2=htsget"
@@ -41,6 +41,7 @@ services:
       POSTGRES_USERNAME_FILE: "/run/secrets/metadata-db-user"
       POSTGRES_PASSWORD_FILE: "/run/secrets/metadata-db-secret"
       AGGREGATE_COUNT_THRESHOLD: ${AGGREGATE_COUNT_THRESHOLD}
+      CURL_CA_BUNDLE: "/etc/ssl/certs/ca-certificates.crt"
     extra_hosts:
       - "${CANDIG_DOMAIN}:${LOCAL_IP_ADDR}"
     healthcheck:


### PR DESCRIPTION
Adding the environment variable as suggested [here](https://github.com/pysam-developers/pysam/issues/1257#issuecomment-2102429054) fixes the issue and now we can update python to 3.12.