### PR TITLE
Removing minio from the stack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -334,7 +334,7 @@ docker-push:
 
 #<<<
 .PHONY: docker-secrets
-docker-secrets: mkdir minio-secrets katsu-secrets
+docker-secrets: mkdir katsu-secrets #minio-secrets
 
 	@echo admin > tmp/secrets/keycloak-admin-user
 	$(MAKE) secret-keycloak-admin-password
@@ -371,8 +371,8 @@ docker-secrets: mkdir minio-secrets katsu-secrets
 docker-volumes:
 	docker volume create grafana-data --label candigv2=volume
 	docker volume create jupyter-data --label candigv2=volume
-	docker volume create minio-config --label candigv2=volume
-	docker volume create minio-data $(MINIO_VOLUME_OPT) --label candigv2=volume
+	# docker volume create minio-config --label candigv2=volume
+	# docker volume create minio-data $(MINIO_VOLUME_OPT) --label candigv2=volume
 	docker volume create prometheus-data --label candigv2=volume
 	docker volume create toil-jobstore --label candigv2=volume
 	docker volume create keycloak-data --label candigv2=volume

--- a/etc/env/example.env
+++ b/etc/env/example.env
@@ -2,8 +2,8 @@
 # - - -
 
 # site options
-CANDIG_MODULES=keycloak vault minio redis postgres htsget katsu query tyk opa federation candig-ingest candig-data-portal
-    #drs-server wes-server logging monitoring
+CANDIG_MODULES=keycloak vault redis postgres htsget katsu query tyk opa federation candig-ingest candig-data-portal
+    #minio drs-server wes-server logging monitoring
 CANDIG_AUTH_MODULES=keycloak vault tyk opa
 
 # options are [<ip_addr>, <url>, host.docker.internal, candig.docker.internal]

--- a/lib/candigv2/docker-compose.yml
+++ b/lib/candigv2/docker-compose.yml
@@ -1,8 +1,8 @@
 volumes:
-  minio-data:
-    external: true
-  minio-config:
-    external: true
+  # minio-data:
+  #   external: true
+  # minio-config:
+  #   external: true
   toil-jobstore:
     external: true
   prometheus-data:
@@ -59,14 +59,14 @@ secrets:
     file: $PWD/lib/katsu/settings.py
     labels:
       - "candigv2=secret"
-  minio-access-key:
-    file: $PWD/tmp/secrets/minio-access-key
-    labels:
-      - "candigv2=secret"
-  minio-secret-key:
-    file: $PWD/tmp/secrets/minio-secret-key
-    labels:
-      - "candigv2=secret"
+  # minio-access-key:
+  #   file: $PWD/tmp/secrets/minio-access-key
+  #   labels:
+  #     - "candigv2=secret"
+  # minio-secret-key:
+  #   file: $PWD/tmp/secrets/minio-secret-key
+  #   labels:
+  #     - "candigv2=secret"
   portainer-user:
     file: $PWD/tmp/secrets/portainer-user
     labels:

--- a/lib/htsget/docker-compose.yml
+++ b/lib/htsget/docker-compose.yml
@@ -16,10 +16,6 @@ services:
         target: vault-s3-token
       - source: opa-service-token
         target: opa-service-token
-      - source: minio-access-key
-        target: minio-access-key
-      - source: minio-secret-key
-        target: minio-secret-key
       - source: metadata-db-secret
         target: metadata-db-secret
       - source: metadata-db-user
@@ -29,7 +25,6 @@ services:
       HTSGET_URL: ${TYK_LOGIN_TARGET_URL}/${TYK_HTSGET_API_LISTEN_PATH}
       OPA_URL: ${OPA_PRIVATE_URL}
       VAULT_URL: ${VAULT_PRIVATE_URL}
-      MINIO_URL: ${MINIO_PRIVATE_URL}
       DEBUG_MODE: ${CANDIG_DEBUG_MODE}
       DB_PATH: "metadata-db"
       SERVER_LOCAL_DATA: /app/htsget_server/data

--- a/lib/templates/docker-compose.yml
+++ b/lib/templates/docker-compose.yml
@@ -20,15 +20,15 @@ services:
     # WARNING: environment variables are world readable
     # DO NOT pass secrets through here
     environment:
-      - MINIO_REGION="${MINIO_REGION}"
+      # - MINIO_REGION="${MINIO_REGION}"
       - CANDIG_DOMAIN="${CANDIG_DOMAIN}"
       - VAULT_URL="${VAULT_PRIVATE_URL}"
       - SERVICE_NAME="${SERVICE_NAME}"
     secrets:
-      - source: minio-access-key
-        target: access_key
-      - source: minio-secret-key
-        target: secret_key
+      # - source: minio-access-key
+      #   target: access_key
+      # - source: minio-secret-key
+      #   target: secret_key
       - source: vault-approle-token
         target: vault-approle-token
     # use entrypoint if you want to override default entrypoint

--- a/settings.py
+++ b/settings.py
@@ -44,7 +44,6 @@ def get_env():
     vars["KEYCLOAK_REALM_URL"] = get_env_value("KEYCLOAK_REALM_URL")
     vars["VAULT_URL"] = get_env_value("VAULT_SERVICE_PUBLIC_URL")
     vars["OPA_URL"] = get_env_value("OPA_URL")
-    vars["MINIO_URL"] = get_env_value("MINIO_PUBLIC_URL")
     vars["TYK_LOGIN_TARGET_URL"] = get_env_value("TYK_LOGIN_TARGET_URL")
     vars["TYK_POLICY_ID"] = get_env_value("TYK_POLICY_ID")
     vars["CANDIG_DEBUG_MODE"] = get_env_value("CANDIG_DEBUG_MODE")
@@ -72,10 +71,6 @@ def get_env():
         vars["VAULT_S3_TOKEN"] = f.read().splitlines().pop()
     with open(f"tmp/vault/keys.txt") as f:
         vars["VAULT_ROOT_TOKEN"] = f.read().splitlines().pop(-1)
-    with open(f"tmp/secrets/minio-access-key") as f:
-        vars["MINIO_ACCESS_KEY"] = f.read().splitlines().pop()
-    with open(f"tmp/secrets/minio-secret-key") as f:
-        vars["MINIO_SECRET_KEY"] = f.read().splitlines().pop()
     with open(f"tmp/secrets/tyk-secret-key") as f:
         vars["TYK_SECRET_KEY"] = f.read().splitlines().pop()
     vars["POSTGRES_PASSWORD_FILE"] = f"tmp/secrets/metadata-db-secret"


### PR DESCRIPTION
We are probably best off not loading up the Minio container if we don't have to: now that it's not used for htsget, I don't think it's used for anything else.