### PR TITLE
sed added to work on WSL

### DIFF
--- a/lib/keycloak/client_setup.sh
+++ b/lib/keycloak/client_setup.sh
@@ -27,8 +27,11 @@ CREATE_OUTPUT=$(KCADM create clients/$CLIENT_ID/protocol-mappers/models -r $KEYC
     -s protocolMapper=oidc-audience-mapper \
     -s config="{\"included.client.audience\" : \"$KEYCLOAK_CLIENT_ID\",\"id.token.claim\" : \"true\",\"access.token.claim\" : \"true\"}" 2>&1)
 # uncomment the line below to see the output
-# echo $CREATE_OUTPUT
+ echo $CREATE_OUTPUT
 
 # EXPORT: Get the client secret and save it to secrets
-CLIENT_SECRET=$(KCADM get clients/"$CLIENT_ID"/client-secret -r "$KEYCLOAK_REALM" | jq -r '.value')
+# echo $CLIENT_ID
+# echo $(KCADM get clients/"$CLIENT_ID"/client-secret -r "$KEYCLOAK_REALM")
+CLIENT_SECRET=$(docker exec "$KEYCLOAK_CONTAINER_ID" /opt/keycloak/bin/kcadm.sh get clients/"$CLIENT_ID"/client-secret -r "$KEYCLOAK_REALM" | sed -n '/{/,/}/p' | jq -r '.value')
+# echo $CLIENT_SECRET
 echo "$CLIENT_SECRET" > tmp/secrets/keycloak-client-$KEYCLOAK_CLIENT_ID-secret

--- a/lib/keycloak/client_setup.sh
+++ b/lib/keycloak/client_setup.sh
@@ -27,7 +27,7 @@ CREATE_OUTPUT=$(KCADM create clients/$CLIENT_ID/protocol-mappers/models -r $KEYC
     -s protocolMapper=oidc-audience-mapper \
     -s config="{\"included.client.audience\" : \"$KEYCLOAK_CLIENT_ID\",\"id.token.claim\" : \"true\",\"access.token.claim\" : \"true\"}" 2>&1)
 # uncomment the line below to see the output
- echo $CREATE_OUTPUT
+# echo $CREATE_OUTPUT
 
 # EXPORT: Get the client secret and save it to secrets
 # echo $CLIENT_ID


### PR DESCRIPTION
## Description 
Secrets were not building correctly narrowed down to the format returned from `CLIENT_SECRET=$(docker exec "$KEYCLOAK_CONTAINER_ID" /opt/keycloak/bin/kcadm.sh get clients/"$CLIENT_ID"/client-secret -r "$KEYCLOAK_REALM" |  jq -r '.value')` wasn't what jq expected added sed.

@SonQBChau feel free to make changes
