### PR TITLE
Update actions versions

### DIFF
--- a/.github/workflows/candig-testing.yml
+++ b/.github/workflows/candig-testing.yml
@@ -16,7 +16,7 @@ jobs:
        shell: bash -l {0}
     steps:
       - name: Install conda
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
           miniconda-version: "latest"
           channels: conda-forge, defaults
@@ -24,7 +24,7 @@ jobs:
           auto-update-conda: true
           auto-activate-base: true
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup environment file
         run: |
             cp etc/env/example.env example.env
@@ -39,7 +39,7 @@ jobs:
              make mkdir
       - name: Restore Conda environment cache
         id: cache-conda
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ env.CONDA }}
           key: ${{ runner.os }}-conda-${{ hashFiles('etc/venv/requirements.txt') }}
@@ -49,7 +49,7 @@ jobs:
         run: |
               make init-conda
       - name: Save Conda cache
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         if: steps.install-conda.outcome == 'success'
         with:
           path: ${{ env.CONDA }}
@@ -71,7 +71,7 @@ jobs:
         run: docker cp candigv2_vault-runner_1:/vault/vault-audit.log tmp/vault_audit.log 2>&1
       - name: Save container and error logs as artifact
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Post-build error log
           path: |


### PR DESCRIPTION
Some of our actions are on older versions that may be deprecated soon, updating to avoid that and get rid of the warning messages when running actions

To test:
* compare to previous build https://github.com/CanDIG/CanDIGv2/actions/runs/9519738192 and note that there are no longer warnings at the bottom 