### PR TITLE
Create a GH action to automatically notify .env changes

### DIFF
--- a/.github/workflows/slack-notify,yaml
+++ b/.github/workflows/slack-notify,yaml
@@ -1,0 +1,23 @@
+name: Slack Notify on example.env Update
+
+on:
+  pull_request:
+    branches:
+        - develop
+    types:
+        - closed
+    paths:
+      - "etc/env/example.env"
+
+jobs:
+  notify-slack:
+    name: Slack notify
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    steps:
+      - name: post to slack
+        id: slack
+        uses: slackapi/slack-github-action@v1.26.0
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          


### PR DESCRIPTION
This PR introduces a new workflow that runs when there is a PR that gets merged into develop that makes a change to the `example.env` file.

It works via a slack webhook url that triggers the [automated Slack workflow](https://slack.com/shortcuts/Ft077NKR24RG/1f33128f119602601aa4024e79b6da95) (this link can only be used within Slack) which posts the [following message](https://candig.slack.com/archives/C01030VMCUR/p1718751880630029) to the candig-dev channel.
![Screenshot 2024-06-18 at 7 52 37 PM](https://github.com/CanDIG/CanDIGv2/assets/13007987/fee68a02-6ce4-4fde-a666-353b58274742)

Any edits to the message that gets posted need to be made within Slack to the workflow itself.

Was made following the [slack-github-action](https://github.com/slackapi/slack-github-action?tab=readme-ov-file#technique-1-slack-workflow-builder) workflow builder guide. The Slack Webhook URL is saved as a secret in this repo so the github action is able to use it. It is possible to customise it further with a payload but went with this simple version as first version.