### PR TITLE
DIG-1690: Cannot logout on dev bugfix

### DIFF
--- a/lib/tyk/configuration_templates/virtualLogout.js
+++ b/lib/tyk/configuration_templates/virtualLogout.js
@@ -77,7 +77,7 @@ function logoutHandler(request, session, spec) {
     responseObject = {
       Body: "{}",
       Headers: {
-        Location: logoutHelper.logoutUrl(spec, decodedBody.access_token),
+        Location: logoutHelper.logoutUrl(spec, decodedBody.id_token),
         "Set-Cookie": logoutHelper.setCookie(app),
       },
       Code: 302,


### PR DESCRIPTION
# Description

This fixes the bug where you can't logout.

# To test
1. Sign into the data portal
2. Sign out
3. You should be redirected to the signin page, and you should no longer be able to access anything by entering in a new URL.