### PR TITLE
Remove manual ingest from nightly build

### DIFF
--- a/etc/env/nightly_env.sh
+++ b/etc/env/nightly_env.sh
@@ -2,7 +2,6 @@
 # Then, create a crontab to cd into the CanDIG root folder and run nightly_build.sh
 export BOT_TOKEN=<BOT_TOKEN>
 export HOOK_URL=<HOOK_URL>
-export INGEST_PATH=<PATH_TO_CANDIGV2_INGEST>
 export BUILD_PATH=<PATH_TO_BUILD>
 
 # Set this to 1 to skip the git pull step, which may destroy changes in your working directories

--- a/etc/env/nightly_env.sh
+++ b/etc/env/nightly_env.sh
@@ -7,3 +7,5 @@ export BUILD_PATH=<PATH_TO_BUILD>
 
 # Set this to 1 to skip the git pull step, which may destroy changes in your working directories
 export SKIP_GIT=0
+
+sed -i "s@KEEP_TEST_DATA=false@KEEP_TEST_DATA=true@" .env

--- a/nightly_build.sh
+++ b/nightly_build.sh
@@ -78,14 +78,6 @@ if [ $? -ne 0 ]; then
     exit
 fi
 
-# Run the ingestion
-python settings.py
-source env.sh
-cd $INGEST_PATH
-export CLINICAL_DATA_LOCATION=$INGEST_PATH/tests/clinical_ingest.json
-# should be pip install -r requirements.txt, but that didn't seem to work last I checked -- dependency errors?
-pip install -r requirements.txt
-python katsu_ingest.py
 cd $BUILD_PATH
 
 PostToSlack "\`\`\`\nBuild success:\nhttp://candig-dev.hpc4healthlocal:5080/\nusername: $CANDIG_SITE_ADMIN_USER\npassword $(cat ./tmp/keycloak/test-site-admin-password)\nusername: $CANDIG_NOT_ADMIN_USER\npassword $(cat ./tmp/keycloak/test-user-password)\nusername: $CANDIG_NOT_ADMIN2_USER\npassword $(cat ./tmp/keycloak/test-user2-password)\n\`\`\`"

--- a/nightly_build.sh
+++ b/nightly_build.sh
@@ -78,6 +78,8 @@ if [ $? -ne 0 ]; then
     exit
 fi
 
+source env.sh
+
 cd $BUILD_PATH
 
 PostToSlack "\`\`\`\nBuild success:\nhttp://candig-dev.hpc4healthlocal:5080/\nusername: $CANDIG_SITE_ADMIN_USER\npassword $(cat ./tmp/keycloak/test-site-admin-password)\nusername: $CANDIG_NOT_ADMIN_USER\npassword $(cat ./tmp/keycloak/test-user-password)\nusername: $CANDIG_NOT_ADMIN2_USER\npassword $(cat ./tmp/keycloak/test-user2-password)\n\`\`\`"


### PR DESCRIPTION
* Removes ingest of test files from ingest because the build keeps the integration test data now
* Ensures keep_test_data is true in the .env file