### PR TITLE
rename metadata to postgres

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -343,7 +343,7 @@ docker-secrets: mkdir #minio-secrets
 	$(MAKE) secret-keycloak-test-user-password
 	$(MAKE) secret-keycloak-test-user2-password
 
-	$(MAKE) secret-metadata-db-secret
+	$(MAKE) secret-postgres-db-secret
 
 	$(MAKE) secret-tyk-secret-key
 	$(MAKE) secret-tyk-analytics-admin-key

--- a/lib/candigv2/docker-compose.yml
+++ b/lib/candigv2/docker-compose.yml
@@ -27,7 +27,7 @@ volumes:
     external: true
 
 secrets:
-  metadata-db-secret:
+  postgres-db-secret:
     file: $PWD/tmp/postgres/db-secret
     labels:
       - "candigv2=secret"

--- a/lib/htsget/docker-compose.yml
+++ b/lib/htsget/docker-compose.yml
@@ -18,22 +18,22 @@ services:
     secrets:
       - source: vault-approle-token
         target: vault-approle-token
-      - source: metadata-db-secret
-        target: metadata-db-secret
+      - source: postgres-db-secret
+        target: postgres-db-secret
     environment:
       HTSGET_TEST_KEY: "hoodlebug"
       HTSGET_URL: ${TYK_LOGIN_TARGET_URL}/${TYK_HTSGET_API_LISTEN_PATH}
       OPA_URL: ${OPA_PRIVATE_URL}
       VAULT_URL: ${VAULT_PRIVATE_URL}
       DEBUG_MODE: 0 #${CANDIG_DEBUG_MODE}
-      DB_PATH: "metadata-db"
+      DB_PATH: "postgres-db"
       SERVER_LOCAL_DATA: /app/htsget_server/data
       INDEXING_PATH: /home/candig/tmp
       TESTENV_URL: ${HTSGET_PRIVATE_URL}
       POSTGRES_DATABASE: "genomic"
-      POSTGRES_HOST_FILE: "metadata-db"
+      POSTGRES_HOST_FILE: "postgres-db"
       POSTGRES_USERNAME: ${DEFAULT_ADMIN_USER}
-      POSTGRES_PASSWORD_FILE: "/run/secrets/metadata-db-secret"
+      POSTGRES_PASSWORD_FILE: "/run/secrets/postgres-db-secret"
       AGGREGATE_COUNT_THRESHOLD: ${AGGREGATE_COUNT_THRESHOLD}
       CURL_CA_BUNDLE: "/etc/ssl/certs/ca-certificates.crt" # this is for pysam
       SERVICE_NAME: ${SERVICE_NAME}

--- a/lib/katsu/docker-compose.yml
+++ b/lib/katsu/docker-compose.yml
@@ -16,10 +16,10 @@ services:
       - "${CANDIG_DOMAIN}:${LOCAL_IP_ADDR}"
     environment:
       - POSTGRES_DATABASE=metadata
-      - POSTGRES_HOST=metadata-db
+      - POSTGRES_HOST=postgres-db
       - POSTGRES_PORT=5432
       - POSTGRES_USER=${DEFAULT_ADMIN_USER}
-      - POSTGRES_PASSWORD_FILE=/run/secrets/metadata_db_secret
+      - POSTGRES_PASSWORD_FILE=/run/secrets/postgres_db_secret
       - REDIS_PASSWORD_FILE=/run/secrets/redis_secret_key
       - OPA_URL=${OPA_PRIVATE_URL}
       - AGGREGATE_COUNT_THRESHOLD=${AGGREGATE_COUNT_THRESHOLD}
@@ -30,8 +30,8 @@ services:
       - WORKERS=${KATSU_WORKERS}
       - THREADS=${KATSU_THREADS}
     secrets:
-      - source: metadata-db-secret
-        target: metadata_db_secret
+      - source: postgres-db-secret
+        target: postgres_db_secret
       - source: redis-secret-key
         target: redis_secret_key
     labels:

--- a/lib/postgres/docker-compose.yml
+++ b/lib/postgres/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - source: postgres-db-secret
         target: postgres_db_secret
     labels:
-      - "candigv2=chord-metadata"
+      - "candigv2=postgres"
     healthcheck:
       test: export PGPASSWORD=$(< $$POSTGRES_PASSWORD_FILE); psql -d $$POSTGRES_DB -U $$POSTGRES_USER -c "SELECT 1"
       interval: 60s

--- a/lib/postgres/docker-compose.yml
+++ b/lib/postgres/docker-compose.yml
@@ -1,16 +1,12 @@
 services:
-  metadata-db:
+  postgres-db:
     image: postgres:16
-    #volumes:
-      #- katsu-db:/var/lib/postgresql/data
-      #add volume name to lib/{compose,swarm,kubernetes}
-      #add volume name to docker-volumes in Makefile
     ports:
       - "5433:5432"
     environment:
       - POSTGRES_USER=${DEFAULT_ADMIN_USER}
-      - POSTGRES_DB=metadata
-      - POSTGRES_PASSWORD_FILE=/run/secrets/metadata_db_secret
+      - POSTGRES_DB=clinical
+      - POSTGRES_PASSWORD_FILE=/run/secrets/postgres_db_secret
       - POSTGRES_HOST_AUTH_METHOD=password
       - DEBUG_MODE=${CANDIG_DEBUG_MODE}
     extra_hosts:
@@ -22,8 +18,8 @@ services:
       options:
         tag: "{{.Name}}"
     secrets:
-      - source: metadata-db-secret
-        target: metadata_db_secret
+      - source: postgres-db-secret
+        target: postgres_db_secret
     labels:
       - "candigv2=chord-metadata"
     healthcheck:

--- a/lib/postgres/postgres_preflight.sh
+++ b/lib/postgres/postgres_preflight.sh
@@ -9,10 +9,10 @@ LOGFILE=$PWD/tmp/progress.txt
 # if there isn't already a value, store the password in tmp/postgres/db-secret
 mkdir -p tmp/postgres
 if [[ ! -f "tmp/postgres/db-secret" ]]; then
-    mv tmp/secrets/metadata-db-secret tmp/postgres/db-secret
+    mv tmp/secrets/postgres-db-secret tmp/postgres/db-secret
 fi
 
 # if we didn't need this temp secret, delete it
-if [[ -f "tmp/secrets/metadata-db-secret" ]]; then
-    rm tmp/secrets/metadata-db-secret
+if [[ -f "tmp/secrets/postgres-db-secret" ]]; then
+    rm tmp/secrets/postgres-db-secret
 fi

--- a/settings.py
+++ b/settings.py
@@ -75,7 +75,7 @@ def get_env():
             vars["TYK_SECRET_KEY"] = f.read().splitlines().pop()
     vars["POSTGRES_PASSWORD_FILE"] = f"tmp/postgres/db-secret"
     vars["CANDIG_ENV"] = INTERPOLATED_ENV
-    vars["DB_PATH"] = "metadata-db"
+    vars["DB_PATH"] = "postgres-db"
     return vars
 
 


### PR DESCRIPTION
## What's new
- Rename `metadata` to `postgres`

### How to test
- Checkout `rename_db` branch for katsu
- Checkout `rename_db` branch for htsget
- Rebuild and run test integration