### PR TITLE
If token is bad, remove cached token

### DIFF
--- a/site_admin_token.py
+++ b/site_admin_token.py
@@ -37,7 +37,10 @@ def get_site_admin_token(username=None, password=None, refresh_token=None):
             )
 
         if "error" in credentials:
-            os.remove("tmp/site-admin-refresh-token")
+            try:
+                os.remove("tmp/site-admin-refresh-token")
+            except:
+                pass
             return get_site_admin_token()
 
         with open(f"tmp/site-admin-refresh-token", "w") as f:
@@ -45,7 +48,10 @@ def get_site_admin_token(username=None, password=None, refresh_token=None):
 
         return credentials["access_token"]
     except Exception as e:
-        os.remove("tmp/site-admin-refresh-token")
+        try:
+            os.remove("tmp/site-admin-refresh-token")
+        except:
+            pass
         raise authx.auth.CandigAuthError(f"Error obtaining response from keycloak server: {e}")
 
 if __name__ == "__main__":

--- a/site_admin_token.py
+++ b/site_admin_token.py
@@ -37,6 +37,7 @@ def get_site_admin_token(username=None, password=None, refresh_token=None):
             )
 
         if "error" in credentials:
+            os.remove("tmp/site-admin-refresh-token")
             return get_site_admin_token()
 
         with open(f"tmp/site-admin-refresh-token", "w") as f:

--- a/site_admin_token.py
+++ b/site_admin_token.py
@@ -45,6 +45,7 @@ def get_site_admin_token(username=None, password=None, refresh_token=None):
 
         return credentials["access_token"]
     except Exception as e:
+        os.remove("tmp/site-admin-refresh-token")
         raise authx.auth.CandigAuthError(f"Error obtaining response from keycloak server: {e}")
 
 if __name__ == "__main__":


### PR DESCRIPTION
If the refresh token is bad, it'll error out and you need to run the script again. This is annoying. Delete any bad cached refresh token before trying again.