### PR TITLE
Allow Katsu to use refresh tokens as well as access tokens

### DIFF
--- a/lib/katsu/docker-compose.yml
+++ b/lib/katsu/docker-compose.yml
@@ -22,6 +22,8 @@ services:
       - POSTGRES_PASSWORD_FILE=/run/secrets/postgres_db_secret
       - REDIS_PASSWORD_FILE=/run/secrets/redis_secret_key
       - OPA_URL=${OPA_PRIVATE_URL}
+      - VAULT_URL=${VAULT_PRIVATE_URL}
+      - KEYCLOAK_PUBLIC_URL=${KEYCLOAK_PUBLIC_URL}
       - AGGREGATE_COUNT_THRESHOLD=${AGGREGATE_COUNT_THRESHOLD}
       - CACHE_DURATION=${KATSU_CACHE_DURATION}
       - ALLOWED_HOSTS=${KATSU_ALLOWED_HOSTS}
@@ -29,7 +31,10 @@ services:
       - DEBUG_MODE=${CANDIG_DEBUG_MODE}
       - WORKERS=${KATSU_WORKERS}
       - THREADS=${KATSU_THREADS}
+      - SERVICE_NAME=${SERVICE_NAME}
     secrets:
+      - source: vault-approle-token
+        target: vault-approle-token
       - source: postgres-db-secret
         target: postgres_db_secret
       - source: redis-secret-key

--- a/lib/katsu/katsu_setup.sh
+++ b/lib/katsu/katsu_setup.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -Euo pipefail
+
+LOGFILE=$PWD/tmp/progress.txt
+
+# This script runs after the container is composed.
+
+echo ">> waiting for katsu to start"
+ingest=$(docker ps --format "{{.Names}}" | grep katsu_1)
+while [ $? -ne 0 ]
+do
+  echo "..."
+  sleep 1
+  ingest=$(docker ps --format "{{.Names}}" | grep katsu_1)
+done
+sleep 5
+
+
+bash $PWD/create_service_store.sh "katsu"
+
+docker restart $ingest

--- a/lib/katsu/katsu_setup.sh
+++ b/lib/katsu/katsu_setup.sh
@@ -7,16 +7,16 @@ LOGFILE=$PWD/tmp/progress.txt
 # This script runs after the container is composed.
 
 echo ">> waiting for katsu to start"
-ingest=$(docker ps --format "{{.Names}}" | grep katsu_1)
+katsu=$(docker ps --format "{{.Names}}" | grep katsu_1)
 while [ $? -ne 0 ]
 do
   echo "..."
   sleep 1
-  ingest=$(docker ps --format "{{.Names}}" | grep katsu_1)
+  katsu=$(docker ps --format "{{.Names}}" | grep katsu_1)
 done
 sleep 5
 
 
 bash $PWD/create_service_store.sh "katsu"
 
-docker restart $ingest
+docker restart $katsu


### PR DESCRIPTION
# Description
This PR allows Katsu to accept refresh tokens when queried directly, in addition to the usual access tokens.
This builds off of work done in #709 

# To Test
Grab the refresh token from:
```
curl -s --request POST \                                                                                                                                                                                               
   --url 'http://candig.docker.internal:8080/auth/realms/candig/protocol/openid-connect/token' \                                                                                                                                      
   --header 'Content-Type: application/x-www-form-urlencoded' \                                                                                                                                                                       
   --data grant_type=password \                                                                                                                                                                                                       
   --data client_id=local_candig \                                                                                                                                                                                                    
   --data client_secret=$CANDIG_CLIENT_SECRET \                                                                                                                                                                                       
   --data username=$CANDIG_SITE_ADMIN_USER \                                                                                                                                                                                          
   --data password=$CANDIG_SITE_ADMIN_PASSWORD \                                                                                                                                                                                      
   --data scope=openid
```

Then plug it in the below:

```
curl http://candig.docker.internal:8008/v3/authorized/donors/ -H "Authorization: Bearer $TOKEN"
```

It should work with both the refresh&access tokens now.