### PR TITLE
Save logs to a different logs directory

### DIFF
--- a/lib/logging/docker-compose.yml
+++ b/lib/logging/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     image: ${DOCKER_REGISTRY}/fluentd:${FLUENTD_VERSION:-latest}
     volumes:
       - type: bind
-        source: $PWD/tmp/logging
+        source: $PWD/tmp/logs
         target: /logging
     ports:
       - "${FLUENTD_PORT}:24224"

--- a/lib/logging/logging_preflight.sh
+++ b/lib/logging/logging_preflight.sh
@@ -6,5 +6,5 @@ LOGFILE=$PWD/tmp/progress.txt
 
 # This script runs before the container is composed.
 
-mkdir -p tmp/logging
-chmod a+w tmp/logging
+mkdir -p tmp/logs
+chmod a+w tmp/logs


### PR DESCRIPTION
I just realized that saving the logs to a directory called `tmp/logging` means that the `make clean-logging` target will delete the logs every time we clean-all. It would be safer to save them to a differently-named directory; I've chosen `tmp/logs`.