### PR TITLE
DIG-1769: backup and restore vault

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -561,3 +561,10 @@ rebuild-keep-data:
 	# Rebuild everything
 	$(foreach MODULE, $(CANDIG_MODULES), $(MAKE) build-$(MODULE); $(MAKE) compose-$(MODULE);)
 	./post_build.sh
+
+
+# wrapper for make_backup.sh to make sure we're running it from the right directory
+backup-vault:
+	@bash lib/vault/make_backup.sh
+	-$(MAKE) compose-vault
+	-$(MAKE) compose-opa

--- a/Makefile
+++ b/Makefile
@@ -573,5 +573,9 @@ backup-vault:
 # if there is a restore file available, restore it and then run compose-opa again
 restore-vault:
 	ls lib/vault/restore.tar.gz
+	-$(MAKE) clean-vault
+	-$(MAKE) secret-vault-approle-token
+	-$(MAKE) docker-volumes
+	-$(MAKE) build-vault
 	-$(MAKE) compose-vault
 	-$(MAKE) compose-opa

--- a/Makefile
+++ b/Makefile
@@ -568,3 +568,10 @@ backup-vault:
 	@bash lib/vault/make_backup.sh
 	-$(MAKE) compose-vault
 	-$(MAKE) compose-opa
+
+
+# if there is a restore file available, restore it and then run compose-opa again
+restore-vault:
+	ls lib/vault/restore.tar.gz
+	-$(MAKE) compose-vault
+	-$(MAKE) compose-opa

--- a/lib/vault/configuration_templates/vault-config.json.tpl
+++ b/lib/vault/configuration_templates/vault-config.json.tpl
@@ -1,5 +1,5 @@
 {
-  "backend": {
+  "storage": {
     "file": {
       "path": ${VAULT_FILE_PATH}
     }

--- a/lib/vault/make_backup.sh
+++ b/lib/vault/make_backup.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+vault=$(docker ps -a --format "{{.Names}}" | grep vault_1 | awk '{print $1}')
+vault_runner=$(docker ps -a --format "{{.Names}}" | grep vault-runner_1 | awk '{print $1}')
+
+mkdir -p $(pwd)/tmp/vault/backup
+stop=$(docker stop $vault)
+zip=$(docker exec $vault_runner bash -c "cd /vault; tar -cz data/ > backup.tar.gz")
+copy=$(docker cp $vault_runner:/vault/backup.tar.gz $(pwd)/tmp/vault/backup/)
+
+cp $(pwd)/tmp/vault/keys.txt $(pwd)/tmp/vault/backup
+pwd=$(pwd)
+cd $(pwd)/tmp/vault
+tar -cz backup > backup.tar.gz
+rm -R backup
+cd $pwd
+
+start=$(docker start $vault)

--- a/lib/vault/make_backup.sh
+++ b/lib/vault/make_backup.sh
@@ -10,6 +10,7 @@ zip=$(docker exec $vault_runner bash -c "cd /vault; tar -cz data/ > backup.tar.g
 copy=$(docker cp $vault_runner:/vault/backup.tar.gz $(pwd)/tmp/vault/backup/)
 
 cp $(pwd)/tmp/vault/keys.txt $(pwd)/tmp/vault/backup
+cp $(pwd)/tmp/vault/service_stores.txt $(pwd)/tmp/vault/backup
 pwd=$(pwd)
 cd $(pwd)/tmp/vault
 tar -cz backup > backup.tar.gz

--- a/lib/vault/make_backup.sh
+++ b/lib/vault/make_backup.sh
@@ -4,6 +4,7 @@ vault=$(docker ps -a --format "{{.Names}}" | grep vault_1 | awk '{print $1}')
 vault_runner=$(docker ps -a --format "{{.Names}}" | grep vault-runner_1 | awk '{print $1}')
 
 mkdir -p $(pwd)/tmp/vault/backup
+docker exec $vault vault auth disable approle/
 stop=$(docker stop $vault)
 zip=$(docker exec $vault_runner bash -c "cd /vault; tar -cz data/ > backup.tar.gz")
 copy=$(docker cp $vault_runner:/vault/backup.tar.gz $(pwd)/tmp/vault/backup/)

--- a/lib/vault/vault_setup.sh
+++ b/lib/vault/vault_setup.sh
@@ -41,6 +41,7 @@ if [[ -f "lib/vault/restore.tar.gz" ]]; then
   docker cp lib/vault/tmp/backup/keys.txt $vault_runner:/vault/config/
   docker cp lib/vault/tmp/backup/backup.tar.gz $vault_runner:/vault/
   docker exec $vault_runner bash -c "cd /vault; tar -xzf backup.tar.gz"
+  rm -R lib/vault/tmp/backup
   mv lib/vault/restore.tar.gz lib/vault/restored.tar.gz
 fi
 

--- a/lib/vault/vault_setup.sh
+++ b/lib/vault/vault_setup.sh
@@ -24,7 +24,25 @@ ingest="candig-ingest"
 # https://www.vaultproject.io/api-docs/secret/identity/entity#batch-delete-entities
 
 vault=$(docker ps -a --format "{{.Names}}" | grep vault_1 | awk '{print $1}')
+vault_runner=$(docker ps -a --format "{{.Names}}" | grep vault-runner_1 | awk '{print $1}')
+
 docker cp lib/vault/tmp/vault-config.json $vault:/vault/config/
+
+
+# check to see if we need to restore a backup before initializing a fresh Vault:
+if [[ -f "lib/vault/restore.tar.gz" ]]; then
+  echo ">> restoring vault from backup"
+  docker stop $vault
+  pwd=$(pwd)
+  cd lib/vault/tmp
+  tar -xzf $pwd/lib/vault/restore.tar.gz
+  cd $pwd
+  cp lib/vault/tmp/backup/keys.txt tmp/vault/
+  docker cp lib/vault/tmp/backup/keys.txt $vault_runner:/vault/config/
+  docker cp lib/vault/tmp/backup/backup.tar.gz $vault_runner:/vault/
+  docker exec $vault_runner bash -c "cd /vault; tar -xzf backup.tar.gz"
+  mv lib/vault/restore.tar.gz lib/vault/restored.tar.gz
+fi
 
 # if vault isn't started, start it:
 docker restart $vault
@@ -139,7 +157,6 @@ docker exec $vault sh -c "echo 'path \"opa/data\" {capabilities = [\"update\", \
 # Htsget needs access to the ingest store's aws path:
 docker exec $vault sh -c "echo 'path \"candig-ingest/aws/*\" {capabilities = [\"read\"]}' >> htsget-policy.hcl; vault policy write htsget htsget-policy.hcl"
 
-vault_runner=$(docker ps -a --format "{{.Names}}" | grep vault-runner_1 | awk '{print $1}')
 docker restart $vault_runner
 
 if [ -f tmp/vault/service_stores.txt ]; then

--- a/lib/vault/vault_setup.sh
+++ b/lib/vault/vault_setup.sh
@@ -38,6 +38,7 @@ if [[ -f "lib/vault/restore.tar.gz" ]]; then
   tar -xzf $pwd/lib/vault/restore.tar.gz
   cd $pwd
   cp lib/vault/tmp/backup/keys.txt tmp/vault/
+  cp lib/vault/tmp/backup/service_stores.txt tmp/vault/
   docker cp lib/vault/tmp/backup/keys.txt $vault_runner:/vault/config/
   docker cp lib/vault/tmp/backup/backup.tar.gz $vault_runner:/vault/
   docker exec $vault_runner bash -c "cd /vault; tar -xzf backup.tar.gz"


### PR DESCRIPTION
To test: make sure you've added something extra to your existing vault setup, like adding user1 to the site curators:
```
curl -X "POST" "http://candig.docker.internal:5080/ingest/site-role/curator/email/user1@test.ca" \
     -H 'Authorization: Bearer <site admin token>' \
     -H 'Content-Type: application/json; charset=utf-8' \
     -d $'{}'
```

Then run the target `make backup-vault`. The backup file will be in tmp/vault/backup.tar.gz.

To restore, run `make clean-vault` and then copy that backup file to `lib/vault/restore.tar.gz`. Then run `make restore-vault`. The backup file will be renamed to `lib/vault/restored.tar.gz` so that you can remove it or not at your leisure.

Then when you check your site curators, user1 should still be there:
```
curl "http://candig.docker.internal:5080/ingest/site-role/curator" \
     -H 'Authorization: Bearer <site admin token>' \
     -H 'Content-Type: application/json; charset=utf-8' \
     -d $'{}'
```