### PR TITLE
increase default aggregate threshold

### DIFF
--- a/etc/env/example.env
+++ b/etc/env/example.env
@@ -48,7 +48,7 @@ DOCKER_REGISTRY=candig
 ALPINE_VERSION=3.18
 
 # WARNING: Do not change this value unless indicated by MOHCCN policy
-AGGREGATE_COUNT_THRESHOLD=5
+AGGREGATE_COUNT_THRESHOLD=10
 
 # logging services
 #TODO: test monitoring version updates


### PR DESCRIPTION
Increase the default aggregate threshold in the example env to 10