### PR TITLE
CanDIG/candig-opa merging: hotfix: site curator only relevant for curateable path/method

### DIFF
--- a/etc/tests/test_integration.py
+++ b/etc/tests/test_integration.py
@@ -651,8 +651,8 @@ def user_access():
             "CANDIG_NOT_ADMIN2_USER",
             "CANDIG_NOT_ADMIN2_PASSWORD",
             "NA02102-bam",
-            True
-        ),  # user2 can access NA02102-bam because site curator
+            False
+        ),  # user2 cannot access NA02102-bam
         (
             "CANDIG_NOT_ADMIN2_USER",
             "CANDIG_NOT_ADMIN2_PASSWORD",


### PR DESCRIPTION
PR triggered by update to develop branch on CanDIG/candig-opa. Commit hash: `820a02f92d388ea385c0c21aeae396df7286108a`. PR link: [#71](https://github.com/CanDIG/candig-opa/pull/71)