### PR TITLE
Bugfix: Nightly build was not actually storing/sending the git response when erroring out

### DIFF
--- a/nightly_build.sh
+++ b/nightly_build.sh
@@ -22,7 +22,7 @@ docker system prune -af
 # But also we need to check that we can't just merge the .env file
 if [[ $SKIP_GIT -ne 1 ]]; then
     git stash push -m "NIGHTLY_STASH"
-    git pull >tmp/gitpull.txt
+    git pull 2<&1 >tmp/gitpull.txt
 
     if [ $? -ne 0 ]; then
         PostToSlack "Could not automatically pull git repo: $(cat tmp/gitpull.txt)"

--- a/nightly_build.sh
+++ b/nightly_build.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 PostToSlack () {
-    SAFE_TEXT=${1@Q}
+    # Single quoting the string breaks formatting, so instead we rely on the \" -> \\" to make sure this doesn't break the curl
+    # SAFE_TEXT=${1@Q}
     SAFE_TEXT=${SAFE_TEXT//\"/\\\"}
     curl -X POST -H 'Content-type: application/json' --data "{\"text\":\"$SAFE_TEXT\"}" $HOOK_URL
 }

--- a/nightly_build.sh
+++ b/nightly_build.sh
@@ -23,10 +23,10 @@ docker system prune -af
 # But also we need to check that we can't just merge the .env file
 if [[ $SKIP_GIT -ne 1 ]]; then
     git stash push -m "NIGHTLY_STASH"
-    git pull 2<&1 >tmp/gitpull.txt
+    git pull >tmp/gitpull.txt 2<&1
 
     if [ $? -ne 0 ]; then
-        PostToSlack "Could not automatically pull git repo: $(cat tmp/gitpull.txt)"
+        PostToSlack "Could not automatically pull git repo:\n\`\`\`$(cat tmp/gitpull.txt)\`\`\`"
         exit
     fi
 
@@ -36,9 +36,9 @@ if [[ $SKIP_GIT -ne 1 ]]; then
     STASH_TEXT=$(git stash list | grep "NIGHTLY_STASH")
     if [[ ! -z $STASH_TEXT ]]; then
         [[ $STASH_TEXT =~ \{([[:digit:]]+)\} ]]
-        git stash pop ${BASH_REMATCH[1]} 2<&1 >tmp/stashapply.txt
+        git stash pop ${BASH_REMATCH[1]} >tmp/stashapply.txt 2<&1
         if [ $? -ne 0 ]; then
-            PostToSlack "Could not automatically merge git repo: $(cat tmp/stashapply.txt)"
+            PostToSlack "Could not automatically merge git repo:\n\`\`\`$(cat tmp/stashapply.txt)\`\`\`"
             exit
         fi
     fi
@@ -52,10 +52,10 @@ make bin-conda
 source bin/miniconda3/etc/profile.d/conda.sh
 make init-conda
 conda activate candig
-make build-all BUILD_OPTS="--no-cache" ARGS="-s" 2<&1 >tmp/lastbuild.txt
+make build-all BUILD_OPTS="--no-cache" ARGS="-s" >tmp/lastbuild.txt 2<&1
 
 if [ $? -ne 0 ]; then
-    PostToSlack "Build failed:\n $(tail tmp/lastbuild.txt)"
+    PostToSlack "Build failed:\n\`\`\`$(tail tmp/lastbuild.txt)\`\`\`"
     exit
 fi
 
@@ -73,9 +73,9 @@ do
     fi
 done
 
-make test-integration 2<&1 >tmp/integration-build.txt
+make test-integration >tmp/integration-build.txt 2<&1
 if [ $? -ne 0 ]; then
-    PostToSlack "Integration tests failed:\n $(tail tmp/integration-build.txt)"
+    PostToSlack "Integration tests failed:\n\`\`\`$(tail tmp/integration-build.txt)\`\`\`"
     exit
 fi
 

--- a/nightly_build.sh
+++ b/nightly_build.sh
@@ -3,7 +3,7 @@
 PostToSlack () {
     # Single quoting the string breaks formatting, so instead we rely on the \" -> \\" to make sure this doesn't break the curl
     # SAFE_TEXT=${1@Q}
-    SAFE_TEXT=${SAFE_TEXT//\"/\\\"}
+    SAFE_TEXT=${1//\"/\\\"}
     curl -X POST -H 'Content-type: application/json' --data "{\"text\":\"$SAFE_TEXT\"}" $HOOK_URL
 }
 


### PR DESCRIPTION
`'Could not automatically pull git repo: '` messages we get were all missing the reason the git repo could not be pulled, which are usually just that the branch does not exist.