### PR TITLE
Update api_ingest.json.tpl

### DIFF
--- a/lib/tyk/configuration_templates/api_ingest.json.tpl
+++ b/lib/tyk/configuration_templates/api_ingest.json.tpl
@@ -16,7 +16,7 @@
 
     "proxy": {
         "target_url": "${TYK_INGEST_API_TARGET}",
-        "strip_listen_path": true,
+        "strip_listen_path": false,
         "disable_strip_slash": false,
         "listen_path": "/${TYK_INGEST_API_LISTEN_PATH}",
         "transport": {


### PR DESCRIPTION
If we're providing the url in the openapi schema in https://github.com/CanDIG/candigv2-ingest/pull/133, we need to make sure that the listen path is not getting stripped by tyk.