### PR TITLE
DIG-1854: update clean-authx and init-authx

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -418,6 +418,7 @@ docker-volumes:
 .PHONY: init-authx
 init-authx: mkdir
 	$(MAKE) docker-volumes
+	$(MAKE) authx-secrets
 	$(foreach MODULE, $(CANDIG_AUTH_MODULES), $(MAKE) build-$(MODULE); $(MAKE) compose-$(MODULE); python settings.py;)
 
 

--- a/Makefile
+++ b/Makefile
@@ -357,19 +357,34 @@ docker-push:
 
 #<<<
 .PHONY: docker-secrets
-docker-secrets: mkdir #minio-secrets
+docker-secrets: mkdir authx-secrets data-secrets #minio-secrets
+
+
+data-secrets: mkdir
+	@echo "making data secrets"
+	$(MAKE) secret-postgres-db-secret
+	$(MAKE) secret-redis-secret-key
+
+
+authx-secrets: mkdir
+	@echo "making authx secrets"
 	$(MAKE) secret-keycloak-admin-password
 
 	$(MAKE) secret-keycloak-test-site-admin-password
 	$(MAKE) secret-keycloak-test-user-password
 	$(MAKE) secret-keycloak-test-user2-password
 
-	$(MAKE) secret-postgres-db-secret
-
 	$(MAKE) secret-tyk-secret-key
 	$(MAKE) secret-tyk-analytics-admin-key
 
-	$(MAKE) secret-redis-secret-key
+
+minio-secrets: mkdir
+	@echo "making minio secrets"
+	@echo $(DEFAULT_ADMIN_USER) > tmp/secrets/minio-access-key
+	$(MAKE) secret-minio-secret-key
+	@echo '[default]' > tmp/secrets/aws-credentials
+	@echo "aws_access_key_id=`cat tmp/secrets/minio-access-key`" >> tmp/secrets/aws-credentials
+	@echo "aws_secret_access_key=`cat tmp/secrets/minio-secret-key`" >> tmp/secrets/aws-credentials
 
 
 #>>>
@@ -436,19 +451,6 @@ init-conda:
 #<<<
 .PHONY: init-docker
 init-docker: docker-volumes docker-secrets
-
-
-#>>>
-# generate secrets for minio server/client
-# make minio-secrets
-
-#<<<
-minio-secrets:
-	@echo $(DEFAULT_ADMIN_USER) > tmp/secrets/minio-access-key
-	$(MAKE) secret-minio-secret-key
-	@echo '[default]' > tmp/secrets/aws-credentials
-	@echo "aws_access_key_id=`cat tmp/secrets/minio-access-key`" >> tmp/secrets/aws-credentials
-	@echo "aws_secret_access_key=`cat tmp/secrets/minio-secret-key`" >> tmp/secrets/aws-credentials
 
 
 #>>>

--- a/Makefile
+++ b/Makefile
@@ -179,7 +179,10 @@ clean-all: clean-logs clean-compose clean-containers clean-secrets \
 #<<<
 .PHONY: clean-authx
 clean-authx:
+	mv tmp/vault/service_stores.txt tmp/vault_service_stores.txt
 	$(foreach MODULE, $(CANDIG_AUTH_MODULES), $(MAKE) clean-$(MODULE);)
+	-mkdir tmp/vault
+	mv tmp/vault_service_stores.txt tmp/vault/service_stores.txt
 
 
 # Empties error and progress logs

--- a/etc/env/example.env
+++ b/etc/env/example.env
@@ -4,7 +4,7 @@
 # site options
 CANDIG_MODULES=logging keycloak vault redis postgres htsget katsu query tyk opa federation candig-ingest candig-data-portal
     #minio drs-server wes-server monitoring
-CANDIG_AUTH_MODULES=keycloak vault tyk opa
+CANDIG_AUTH_MODULES=keycloak vault tyk opa federation
 CANDIG_DATA_MODULES=keycloak vault redis postgres logging
 
 # options are [<ip_addr>, <url>, host.docker.internal, candig.docker.internal]


### PR DESCRIPTION
We haven't refactored clean/init-authx since we redid docker secrets and moved to vault secret stores. I think these changes should be sufficient to make things work again.
