### PR TITLE
hotfix: save temporary files

### DIFF
--- a/.github/workflows/candig-testing.yml
+++ b/.github/workflows/candig-testing.yml
@@ -67,6 +67,13 @@ jobs:
       - name: Save docker container logs
         if: always()
         run: ./print_logs.sh > tmp/container_logs.txt 2>&1
+      - name: Save any intermediate files in containers
+        if: always()
+        run: |
+              mkdir tmp/ingest
+              docker cp candigv2_candig-ingest_1:/home/candig/tmp tmp/ingest 2>&1
+              mkdir tmp/index
+              docker cp candigv2_htsget_1:/home/candig/tmp tmp/index 2>&1
       - name: Save vault audit logs
         if: always()
         run: docker cp candigv2_vault-runner_1:/vault/vault-audit.log tmp/vault_audit.log 2>&1

--- a/.github/workflows/candig-testing.yml
+++ b/.github/workflows/candig-testing.yml
@@ -86,3 +86,5 @@ jobs:
                 tmp/progress.txt
                 tmp/container_logs.txt
                 tmp/vault_audit.log
+                tmp/ingest
+                tmp/index


### PR DESCRIPTION
Save out temporary files in ingest and htsget in case the github test workflow fails in some way, so that we can inspect the files.

You can see the files in the post-build artifacts: https://github.com/CanDIG/CanDIGv2/actions/runs/12090019799/artifacts/2255285496