### PR TITLE
Only post output if error is unexpected

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -290,7 +290,6 @@ compose-%:
 	python settings.py; source env.sh; \
 	export SERVICE_NAME=$*; \
 	docker compose -f lib/candigv2/docker-compose.yml -f lib/$*/docker-compose.yml --compatibility up -d 2>&1 | tee -a $(LOGFILE)
-	cat tmp/containers.txt
 	if [ $(found) -eq 0 ]; then \
 	echo $(containers) >> tmp/containers.txt; \
 	fi

--- a/create_service_store.sh
+++ b/create_service_store.sh
@@ -52,7 +52,7 @@ create_service_store() {
             docker exec $vault sh -c "vault read -field=role_id auth/approle/role/${service}/role-id" > tmp/vault/$service-roleid
 
             echo "create a kv store for $service"
-            docker exec $vault vault secrets enable -path=$service -description="${service} kv store" kv
+            bash $PWD/exec_with_expected.sh "docker exec $vault vault secrets enable -path=$service -description=\"${service} kv store\" kv" "path is already in use"
         fi
 
         # get names of containers for service:
@@ -61,8 +61,8 @@ create_service_store() {
         do
             # copy roleid to container
             container=$(echo ${container} | tr -d "'")
-            docker cp $PWD/tmp/vault/${service}-roleid candigv2_${container}_1:/home/candig/roleid
-            docker cp $PWD/tmp/vault/approle-token candigv2_${container}_1:/home/candig/approle-token
+            bash $PWD/exec_with_expected.sh "docker cp $PWD/tmp/vault/${service}-roleid candigv2_${container}_1:/home/candig/roleid" "Error response from daemon: Could not find the file /home/candig"
+            bash $PWD/exec_with_expected.sh "docker cp $PWD/tmp/vault/approle-token candigv2_${container}_1:/home/candig/approle-token" "Error response from daemon: Could not find the file /home/candig"
         done
         # if we're not in debug mode, delete the tmp roleid file
         if [[ ${CANDIG_DEBUG_MODE:-"0"} == "0" ]]; then

--- a/create_service_store.sh
+++ b/create_service_store.sh
@@ -26,10 +26,10 @@ create_service_store() {
             ips=$(collect_ips $service)
             ips+="${gateway}/32"
 
-            echo "create a policy for $service's access to the approle role and secret"
+            echo ">> create a policy for $service's access to the approle role and secret"
             docker exec $vault sh -c "echo 'path \"auth/approle/role/${service}/role-id\" {capabilities = [\"read\"]}' >> ${service}-policy.hcl; echo 'path \"auth/approle/role/${service}/secret-id\" {capabilities = [\"update\"]}' >> ${service}-policy.hcl; vault policy write ${service} ${service}-policy.hcl"
 
-            echo "create an approle for $service"
+            echo ">> create an approle for $service"
             cmd="vault write auth/approle/role/${service} secret_id_ttl=10m token_ttl=20m token_max_ttl=30m token_policies=${service}"
             if [ $CANDIG_DEBUG_MODE -eq 0 ]; then
               cmd+=" secret_id_bound_cidrs=${ips} token_bound_cidrs=${ips}"
@@ -48,10 +48,10 @@ create_service_store() {
                 docker exec $vault sh -c "echo 'path \"${service}/*\" {capabilities = [\"create\", \"update\", \"read\", \"delete\"]}' >> opa-policy.hcl; vault policy write opa opa-policy.hcl"
             fi
 
-            echo "save the role id to secrets"
+            echo ">> save the role id to secrets"
             docker exec $vault sh -c "vault read -field=role_id auth/approle/role/${service}/role-id" > tmp/vault/$service-roleid
 
-            echo "create a kv store for $service"
+            echo ">> create a kv store for $service"
             bash $PWD/exec_with_expected.sh "docker exec $vault vault secrets enable -path=$service -description=\"${service} kv store\" kv" "path is already in use"
         fi
 
@@ -61,6 +61,7 @@ create_service_store() {
         do
             # copy roleid to container
             container=$(echo ${container} | tr -d "'")
+            echo ">> create secret files in $container"
             bash $PWD/exec_with_expected.sh "docker cp $PWD/tmp/vault/${service}-roleid candigv2_${container}_1:/home/candig/roleid" "Error response from daemon: Could not find the file /home/candig"
             bash $PWD/exec_with_expected.sh "docker cp $PWD/tmp/vault/approle-token candigv2_${container}_1:/home/candig/approle-token" "Error response from daemon: Could not find the file /home/candig"
         done

--- a/exec_with_expected.sh
+++ b/exec_with_expected.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# run a command and check to see if the error message is the expected (innocuous) error. Only print output if it's not the expected error.
+cmd=$1
+expected=$2
+echo $cmd | bash &> .tmp_store
+
+grep -q "$expected" .tmp_store
+
+if [[ $? -ne 0 ]]; then
+    cat .tmp_store
+fi
+rm .tmp_store
+

--- a/lib/federation/federation_setup.sh
+++ b/lib/federation/federation_setup.sh
@@ -20,4 +20,5 @@ source env.sh
 bash $PWD/create_service_store.sh "federation"
 docker restart $federation
 
+sleep 5
 python $PWD/lib/federation/initialize.py


### PR DESCRIPTION
Inspired by #901, I decided to write a wrapper bash script that runs a command and compares it to the expected output. If the error that is outputted by the command is one that is expected, then it will just pass silently; it will only output the error if it was something unexpected.

This cleans up a few of the last expected-errors that we get in `make build-all`: if you build a clean stack, you shouldn't get any errors at all now.