### PR TITLE
DIG-1836: fix snyk vulnerabilities

### DIFF
--- a/etc/venv/requirements.txt
+++ b/etc/venv/requirements.txt
@@ -1,14 +1,16 @@
 docker
 python-dotenv
 tox
-connexion
+connexion>=3.1.0
 aiohttp
 requests
 pytest
 pytz
 candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.6.1
 minio==7.2.12
-werkzeug>=2.3.8 # not directly required, pinned by Snyk to avoid a vulnerability
 clinical_etl@git+https://github.com/CanDIG/clinical_ETL_code.git@v3.1.0
 GitPython
 candigv2-logging@git+https://github.com/CanDIG/candigv2-logging.git@v1.0.1
+werkzeug>=2.3.8 # not directly required, pinned by Snyk to avoid a vulnerability
+python-multipart>=0.0.18 # not directly required, pinned by Snyk to avoid a vulnerability
+starlette>=0.40.0 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/etc/venv/requirements.txt
+++ b/etc/venv/requirements.txt
@@ -6,9 +6,9 @@ aiohttp
 requests
 pytest
 pytz
-candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.6.0
-minio==7.1.12
+candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.6.1
+minio==7.2.12
 werkzeug>=2.3.8 # not directly required, pinned by Snyk to avoid a vulnerability
 clinical_etl@git+https://github.com/CanDIG/clinical_ETL_code.git@v3.1.0
 GitPython
-candigv2-logging@git+https://github.com/CanDIG/candigv2-logging.git@v1.0.0
+candigv2-logging@git+https://github.com/CanDIG/candigv2-logging.git@v1.0.1

--- a/settings.py
+++ b/settings.py
@@ -66,7 +66,7 @@ def get_env():
     if os.path.isfile("tmp/tyk/secret-key"):
         with open("tmp/tyk/secret-key") as f:
             vars["TYK_SECRET_KEY"] = f.read().splitlines().pop()
-    vars["POSTGRES_PASSWORD_FILE"] = f"tmp/postgres/db-secret"
+    vars["POSTGRES_PASSWORD_FILE"] = os.path.abspath(f"tmp/postgres/db-secret")
     vars["CANDIG_ENV"] = INTERPOLATED_ENV
     vars["DB_PATH"] = "postgres-db"
 
@@ -89,6 +89,13 @@ def get_env():
     if os.path.isfile("tmp/keycloak/test-user2-password"):
         with open("tmp/keycloak/test-user2-password") as f:
             vars["CANDIG_NOT_ADMIN2_PASSWORD"] = f.read().splitlines().pop()
+
+    # test setup:
+    if os.path.isfile("tmp/vault/approle-token"):
+        vars["APPROLE_TOKEN_FILE"] = os.path.abspath("tmp/vault/approle-token")
+    if os.path.isfile("tmp/vault/opa-roleid"):
+        vars["ROLE_ID_FILE"] = os.path.abspath("tmp/vault/opa-roleid")
+        vars["SERVICE_NAME"] = "opa"
 
     return vars
 


### PR DESCRIPTION
This passes `snyk test` on my local machine now.

I added some env vars to env.sh so that if you want to run the pytest for candigv2-authx, you can do so from that directory, as long as you're in the candig conda env:

```
(candig) MacBook-Pro:candigv2-authx$ source ../CanDIGv2/env.sh 
(candig) MacBook-Pro:candigv2-authx$ pytest
```