### PR TITLE
Hotfix/freeze opa version

### DIFF
--- a/etc/env/example.env
+++ b/etc/env/example.env
@@ -14,7 +14,7 @@ CANDIG_AUTH_DOMAIN=candig.docker.internal
 CANDIG_SITE_LOCATION=LOCAL # BCGSC, UHN, C3G, etc.
 CANDIG_DEBUG_MODE=1
 CANDIG_PRODUCTION_MODE=0
-CANDIG_VERSION=v5.0.0
+CANDIG_VERSION=v5.0.1
 
 # this is the unique key used by your site IDP to identify users.
 CANDIG_USER_KEY=email

--- a/lib/opa/docker-compose.yml
+++ b/lib/opa/docker-compose.yml
@@ -44,7 +44,8 @@ services:
       - "/app/entrypoint.sh"
 
   opa:
-    image: openpolicyagent/opa:latest-static
+    # image: openpolicyagent/opa:latest-static # branch develop should continue to use latest-static. 
+    image: openpolicyagent/opa:0.69.0-static # Do not merge this frozen version back into branch develop.
     logging:
       driver: "fluentd"
       options:


### PR DESCRIPTION
Latest version of opa (~20-Dec-2024) is a major revision.: 0.71.0 -> 1.0.0.  It breaks the build.
This stable branch needs a frozen Oct-2024 version of opa (0.69.0-static).

#### Other changes

- [ ] All submodule versions have been updated in etc/env/example.env - No changes.
- [x] Update .etc/env/example.env for .env CANDIG_VERSION to current release vX.X.X. The version needs to match tag for linking `https://github.com/CanDIG/CanDIGv2/releases/tag/${CANDIG_VERSION}`
- [ ] Submodules point to latest stable release on each repo - No changes.
- [ ] Appropriate integration tests have been made to validate the changes - None tried.
- [x] Passes integration tests on a development instance
- [ ] Passes [frontend runbook](https://candig.atlassian.net/wiki/spaces/CA/pages/822018050/Frontend+Testing+Runbook) testing
