### PR TITLE
Fixup the genomic tests so that the site is not hardcoded

### DIFF
--- a/etc/tests/test_integration.py
+++ b/etc/tests/test_integration.py
@@ -1187,10 +1187,10 @@ def test_query_completeness():
         f"{ENV['CANDIG_ENV']['QUERY_INTERNAL_URL']}/genomic_completeness").json()
     pprint.pprint(query_response)
     # Verify that the synthetic data shows up
-    assert "LOCAL-SYNTH_01" in query_response
-    assert query_response["LOCAL-SYNTH_01"]["genomes"] == 6
-    assert "LOCAL-SYNTH_02" in query_response
-    assert query_response["LOCAL-SYNTH_02"]["genomes"] == 5
+    assert f"{ENV['CANDIG_ENV']['CANDIG_SITE_LOCATION']}-SYNTH_01" in query_response
+    assert query_response[f"{ENV['CANDIG_ENV']['CANDIG_SITE_LOCATION']}-SYNTH_01"]["genomes"] == 6
+    assert f"{ENV['CANDIG_ENV']['CANDIG_SITE_LOCATION']}-SYNTH_02" in query_response
+    assert query_response[f"{ENV['CANDIG_ENV']['CANDIG_SITE_LOCATION']}-SYNTH_02"]["genomes"] == 5
 
 
 def test_clean_up():


### PR DESCRIPTION
The site was hard-coded for some reason, throwing errors for the genomic tests on non-standard installs.