### PR TITLE
Hotfix: Use stable branch of synth data for integration tests

### DIFF
--- a/lib/candig-ingest/candig-ingest_setup.sh
+++ b/lib/candig-ingest/candig-ingest_setup.sh
@@ -21,4 +21,4 @@ bash $PWD/create_service_store.sh "candig-ingest"
 
 docker restart $ingest
 
-python $PWD/lib/candig-ingest/candigv2-ingest/generate_test_data.py --tmp tmp/data/synthdata --delete
+python $PWD/lib/candig-ingest/candigv2-ingest/generate_test_data.py --tmp tmp/data/synthdata --branch "stable" --delete


### PR DESCRIPTION
Uses the stable branch of mohccn data repo for integration tests by pulling a newer version of the generate_test_data.py from ingest