### PR TITLE
CanDIG/candigv2-ingest merging: Fixes for new endpoints, date validation and README redirects to Docs website

### DIFF
--- a/lib/candig-ingest/candig-ingest_setup.sh
+++ b/lib/candig-ingest/candig-ingest_setup.sh
@@ -27,6 +27,7 @@ site_admin_token=$(python site_admin_token.py)
 if [[ $CANDIG_SITE_ADMIN_USER != "" ]]; then
   echo ">> approving $CANDIG_SITE_ADMIN_USER as a CanDIG authorized user"
   bash $PWD/exec_with_expected.sh "curl -sX \"POST\" \"${CANDIG_URL}/ingest/user/pending/request\" -H \"Authorization: Bearer ${site_admin_token}\"" "$CANDIG_SITE_ADMIN_USER"
+  bash $PWD/exec_with_expected.sh "curl -sX \"POST\" \"${CANDIG_URL}/ingest/user/pending/${CANDIG_SITE_ADMIN_USER}\" -H \"Authorization: Bearer ${site_admin_token}\"" "$CANDIG_SITE_ADMIN_USER"
 fi
 
 python $PWD/lib/candig-ingest/candigv2-ingest/generate_test_data.py --prefix $CANDIG_SITE_LOCATION --tmp tmp/data/synthdata --delete


### PR DESCRIPTION
(also picked up a fix to approve site admin in candig-ingest_setup.sh)

PR triggered by update to develop branch on CanDIG/candigv2-ingest. Commit hash: `be495baf52af37299c8bba3e7e110142655cdf12`. PR link: [#160](https://github.com/CanDIG/candigv2-ingest/pull/160)