### PR TITLE
DIG-1939: Update ingest and script

### DIFF
--- a/lib/candig-ingest/candig-ingest_setup.sh
+++ b/lib/candig-ingest/candig-ingest_setup.sh
@@ -30,4 +30,4 @@ if [[ $CANDIG_SITE_ADMIN_USER != "" ]]; then
   bash $PWD/exec_with_expected.sh "curl -sX \"POST\" \"${CANDIG_URL}/ingest/user/pending/${CANDIG_SITE_ADMIN_USER}\" -H \"Authorization: Bearer ${site_admin_token}\"" "$CANDIG_SITE_ADMIN_USER"
 fi
 
-python $PWD/lib/candig-ingest/candigv2-ingest/generate_test_data.py --prefix $CANDIG_SITE_LOCATION --tmp tmp/data/synthdata --delete
+python $PWD/lib/candig-ingest/candigv2-ingest/generate_test_data.py --commit 7d604a3 --prefix $CANDIG_SITE_LOCATION --tmp tmp/data/synthdata --delete


### PR DESCRIPTION
Updates to allow test data generation to use a specific commit of the mohccn-synthetic-data-repo

to test:
- pull changes and update submodules
- `make recompose candig-ingest`
- run integration tests and make sure everything passes