### PR TITLE
Fixes for site admin tokens

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -286,14 +286,14 @@ found=$(shell grep -ch $(containers) tmp/containers.txt)
 #<<<
 compose-%:
 	@printf "\nOutput of compose-$*: \n" | tee -a $(LOGFILE)
-	@if [ $* != "keycloak" ]; then \
+	@source setup_hosts.sh; \
+	python settings.py; source env.sh; \
+	if [ $* != "keycloak" ]; then \
 	if [ $* != "logging" ]; then \
 	echo "getting site admin token"; \
 	python site_admin_token.py ; \
 	fi \
-	fi
-	source setup_hosts.sh; \
-	python settings.py; source env.sh; \
+	fi; \
 	export SERVICE_NAME=$*; \
 	docker compose -f lib/candigv2/docker-compose.yml -f lib/$*/docker-compose.yml --compatibility up -d 2>&1 | tee -a $(LOGFILE)
 	if [ $(found) -eq 0 ]; then \

--- a/Makefile
+++ b/Makefile
@@ -286,6 +286,12 @@ found=$(shell grep -ch $(containers) tmp/containers.txt)
 #<<<
 compose-%:
 	@printf "\nOutput of compose-$*: \n" | tee -a $(LOGFILE)
+	@if [ $* != "keycloak" ]; then \
+	if [ $* != "logging" ]; then \
+	echo "getting site admin token"; \
+	python site_admin_token.py ; \
+	fi \
+	fi
 	source setup_hosts.sh; \
 	python settings.py; source env.sh; \
 	export SERVICE_NAME=$*; \

--- a/Makefile
+++ b/Makefile
@@ -567,22 +567,24 @@ start-all:
 
 #>>>
 # rebuild the entire stack without touching the data containers, defined in .env
+### $(MAKE) clean-all CANDIG_MODULES="$(CANDIG_MODULES)"
 #<<<
 
 .PHONY: rebuild-keep-data
 rebuild-keep-data:
-	# Remove the module from the .env
-	$(eval CANDIG_MODULES := $(filter-out $(CANDIG_DATA_MODULES),$(CANDIG_MODULES)))
-	# Clean everything
-	$(MAKE) clean-all CANDIG_MODULES="$(CANDIG_MODULES)"
+	# Remove the data modules from CANDIG_MODULES
+	$(eval REBUILD_CANDIG_MODULES := $(filter-out $(CANDIG_DATA_MODULES),$(CANDIG_MODULES)))
+	# Clean only the remaining modules
+	$(foreach MODULE, $(REBUILD_CANDIG_MODULES), $(MAKE) clean-$(MODULE);)
+	# Prune unused Docker resources
 	docker system prune -af
 	# Start build-all
 	./pre-build-check.sh $(ARGS)
 	$(MAKE) init-docker
-	# Rebuild everything
-	$(foreach MODULE, $(CANDIG_MODULES), $(MAKE) build-$(MODULE); $(MAKE) compose-$(MODULE);)
+	# Rebuild deleted modules
+	$(foreach MODULE, $(REBUILD_CANDIG_MODULES), $(MAKE) build-$(MODULE); $(MAKE) compose-$(MODULE);)
+	# Run post-build tasks
 	./post_build.sh
-
 
 # wrapper for make_backup.sh to make sure we're running it from the right directory
 backup-vault:

--- a/site_admin_token.py
+++ b/site_admin_token.py
@@ -12,15 +12,15 @@ def get_site_admin_token(username=None, password=None, refresh_token=None):
         if os.path.isfile("tmp/site-admin-refresh-token"):
             with open("tmp/site-admin-refresh-token") as f:
                 refresh_token = f.read().splitlines().pop()
-
-    # if no refresh token, get one:
-    # check for default site admin user: if not present, check env vars
-    username = os.getenv("CANDIG_SITE_ADMIN_USER")
-    password = os.getenv("CANDIG_SITE_ADMIN_PASSWORD")
-    # site admin user/password need to be inputted on stdin if not default:
-    if password is None or password == "":
-        username = input("Enter username: ")
-        password = getpass.getpass("Enter password: ")
+        else:
+            # if no refresh token saved:
+            # check for default site admin user: if not present, check env vars
+            username = os.getenv("CANDIG_SITE_ADMIN_USER")
+            password = os.getenv("CANDIG_SITE_ADMIN_PASSWORD")
+            # site admin user/password need to be inputted on stdin if not default:
+            if password is None or password == "":
+                username = input("Enter username: ")
+                password = getpass.getpass("Enter password: ")
 
     try:
         credentials = authx.auth.get_oauth_response(


### PR DESCRIPTION
If you're composing a module that is not keycloak or logging (those happen too early), make sure that there is a site admin refresh token saved off, and prompt if there isn't.

To test: on your local system, comment out lines 74-81 in settings.py:
```
    # if get_env_value("DEFAULT_SITE_ADMIN_USER") is not None:
    #     vars["CANDIG_SITE_ADMIN_USER"] = get_env_value("DEFAULT_SITE_ADMIN_USER")
    #     if os.path.isfile("tmp/keycloak/test-site-admin-password"):
    #         with open("tmp/keycloak/test-site-admin-password") as f:
    #             vars["CANDIG_SITE_ADMIN_PASSWORD"] = f.read().splitlines().pop()
    # else:
    #     vars["CANDIG_SITE_ADMIN_USER"] = ""
    #     vars["CANDIG_SITE_ADMIN_PASSWORD"] = ""
```

then run make clean-all and make build-all. You should get through composing logging and keycloak, and when you get to the next module, you should get a username prompt. Enter `site_admin@test.ca` and whatever the password value is in tmp/keycloak/test-site-admin-password. Everything else should build as expected.