### PR TITLE
Allow Keycloak to use proxy headers in development mode

### DIFF
--- a/lib/keycloak/credential_loader.sh
+++ b/lib/keycloak/credential_loader.sh
@@ -10,5 +10,5 @@ export KEYCLOAK_ADMIN_PASSWORD=$(< /run/secrets/keycloak-admin-password)
 if [ "$CANDIG_PRODUCTION_MODE" = 1 ]; then
   exec /opt/keycloak/bin/kc.sh start $cli_settings
 else
-  exec /opt/keycloak/bin/kc.sh start-dev
+  exec /opt/keycloak/bin/kc.sh start-dev $cli_settings
 fi


### PR DESCRIPTION
Allow `KEYCLOAK_PROXY_HEADERS` to work even if we're in development mode.