### PR TITLE
hotfix: need to put comments on later lines

### DIFF
--- a/etc/env/example-production.env
+++ b/etc/env/example-production.env
@@ -9,9 +9,11 @@ CANDIG_DATA_MODULES=keycloak vault redis postgres logging
 
 # options are [<ip_addr>, <url>, host.docker.internal, candig.docker.internal]
 CANDIG_DOMAIN=YOUR_PRODUCTION_DOMAIN
-CANDIG_INTERNAL_DOMAIN=${CANDIG_DOMAIN}  # may need to change to IP address, depends on proxy
+CANDIG_INTERNAL_DOMAIN=${CANDIG_DOMAIN}
+ # may need to change to IP address, depends on proxy
 CANDIG_AUTH_DOMAIN=YOUR_PRODUCTION_AUTH_DOMAIN
-CANDIG_SITE_LOCATION=YOUR_SITE_IDENTIFIER # BCGSC, UHN, C3G, etc.
+CANDIG_SITE_LOCATION=YOUR_SITE_IDENTIFIER
+ # BCGSC, UHN, C3G, etc.
 CANDIG_DEBUG_MODE=0
 CANDIG_PRODUCTION_MODE=1
 CANDIG_VERSION=v5.1.0
@@ -33,7 +35,8 @@ TEST_USER_2=user2@test.ca
 KEEP_TEST_DATA=false
 
 # set this to your local IP address (i.e. 192.168.x.x on most networks) if `make init-authx` cannot automatically determine your IP
-LOCAL_IP_ADDR=  # may need to set this value
+LOCAL_IP_ADDR=
+ # may need to set this value
 
 # miniconda venv
 # options are [linux, darwin, arm64mac]
@@ -162,10 +165,12 @@ KATSU_THREADS=4
 # keycloak service
 KEYCLOAK_VERSION=24.0.0
 KEYCLOAK_REALM=candig
-KEYCLOAK_CLIENT_ID=YOUR_KEYCLOAK_IDENTIFIER  # optional
+KEYCLOAK_CLIENT_ID=YOUR_KEYCLOAK_IDENTIFIER
+ # optional
 KEYCLOAK_LOGIN_REDIRECT_PATH=/auth/login
 KEYCLOAK_PORT=8080
-KEYCLOAK_HTTPS_PORT=8443 # or 443
+KEYCLOAK_HTTPS_PORT=8443
+ # or 443
 KEYCLOAK_PUBLIC_PROTO=https
 KEYCLOAK_PRIVATE_PROTO=http
 KEYCLOAK_PUBLIC_URL=${KEYCLOAK_PUBLIC_PROTO}://${CANDIG_AUTH_DOMAIN}
@@ -176,7 +181,8 @@ KEYCLOAK_GENERATE_TEST_USER=1
 
 # some production instances use a reverse proxy: if needed, set this to "xforwarded" or "forwarded"
 # https://www.keycloak.org/server/reverseproxy
-KEYCLOAK_PROXY_HEADERS=xforwarded # probably (depends on proxy setup)
+KEYCLOAK_PROXY_HEADERS=xforwarded
+ # probably (depends on your proxy setup)
 
 # query service
 QUERY_VERSION=3.4.0


### PR DESCRIPTION
Make seems to keep the spaces as part of the string value; we need to put the comments on the next line.