### PR TITLE
DIG-1993: add a pause after restart during ingest setup

### DIFF
--- a/exec_with_expected.sh
+++ b/exec_with_expected.sh
@@ -9,6 +9,6 @@ grep -q "$expected" .tmp_store
 
 if [[ $? -ne 0 ]]; then
     cat .tmp_store
+    exit 1
 fi
 rm .tmp_store
-

--- a/lib/candig-ingest/candig-ingest_setup.sh
+++ b/lib/candig-ingest/candig-ingest_setup.sh
@@ -21,19 +21,18 @@ sleep 5
 bash $PWD/create_service_store.sh "candig-ingest"
 
 docker restart $ingest
-echo ">> waiting for candig-ingest to restart"
-ingest=$(docker ps --format "{{.Names}}" | grep candig-ingest_1)
-while [ $? -ne 0 ]
-do
-  echo "..."
-  sleep 1
-  ingest=$(docker ps --format "{{.Names}}" | grep candig-ingest_1)
-done
-sleep 2
 
 # If present, create and authorize default site admin as CanDIG authorized user:
 site_admin_token=$(python site_admin_token.py)
 if [[ $CANDIG_SITE_ADMIN_USER != "" ]]; then
+  bash $PWD/exec_with_expected.sh "curl -si \"${CANDIG_URL}/ingest/service-info\" -H \"Authorization: Bearer ${site_admin_token}\"" "200 OK"
+  while [ $? -ne 0 ]
+  do
+    echo "..."
+      sleep 1
+      bash $PWD/exec_with_expected.sh "curl -si \"${CANDIG_URL}/ingest/service-info\" -H \"Authorization: Bearer ${site_admin_token}\"" "200 OK"
+  done
+
   echo ">> approving $CANDIG_SITE_ADMIN_USER as a CanDIG authorized user"
   bash $PWD/exec_with_expected.sh "curl -sX \"POST\" \"${CANDIG_URL}/ingest/user/pending/request\" -H \"Authorization: Bearer ${site_admin_token}\"" "$CANDIG_SITE_ADMIN_USER"
   bash $PWD/exec_with_expected.sh "curl -sX \"POST\" \"${CANDIG_URL}/ingest/user/pending/${CANDIG_SITE_ADMIN_USER}\" -H \"Authorization: Bearer ${site_admin_token}\"" "$CANDIG_SITE_ADMIN_USER"

--- a/lib/candig-ingest/candig-ingest_setup.sh
+++ b/lib/candig-ingest/candig-ingest_setup.sh
@@ -21,6 +21,15 @@ sleep 5
 bash $PWD/create_service_store.sh "candig-ingest"
 
 docker restart $ingest
+echo ">> waiting for candig-ingest to restart"
+ingest=$(docker ps --format "{{.Names}}" | grep candig-ingest_1)
+while [ $? -ne 0 ]
+do
+  echo "..."
+  sleep 1
+  ingest=$(docker ps --format "{{.Names}}" | grep candig-ingest_1)
+done
+sleep 2
 
 # If present, create and authorize default site admin as CanDIG authorized user:
 site_admin_token=$(python site_admin_token.py)


### PR DESCRIPTION
After the service store is set up, the setup script restarts the ingest container, but does not wait to make sure that the container is up and responding before trying to go on and use the API.