### PR TITLE
Remove colour from the NB's output

### DIFF
--- a/nightly_build.sh
+++ b/nightly_build.sh
@@ -74,7 +74,7 @@ do
     fi
 done
 
-make test-integration >tmp/integration-build.txt 2<&1
+make test-integration ARGS="--color=no" >tmp/integration-build.txt 2<&1
 if [ $? -ne 0 ]; then
     PostToSlack "Integration tests failed:\n\`\`\`$(tail tmp/integration-build.txt)\`\`\`"
     exit


### PR DESCRIPTION
Quick fix to the error that NB sometimes encounters -- when it runs integration tests, sometimes the color-output that pytest outputs will mess up its output.