### PR TITLE
Add federation tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -553,6 +553,28 @@ test-integration-%:
 	mkdir -p tmp/test
 	python ./settings.py; source ./env.sh; pytest -v --color=yes ./etc/tests -s -rP -k '$*' --report-log=./tmp/test/test-integration_$(shell date +"%Y-%m-%d_%Hh%Mm%Ss").jsonl
 
+#>>>
+# run local federation setup tests
+# these aren't really federation tests, but instead setup datasets for another site to test their federation
+
+#<<<
+.PHONY: test-local-federation
+test-local-federation:
+	mkdir -p tmp/test
+	python ./settings.py
+	source ./env.sh; pytest -v --color=yes ./etc/tests/federation -k "all or local" $(ARGS) --report-log=./tmp/test/test-federation_$(shell date +"%Y-%m-%d_%Hh%Mm%Ss").jsonl
+
+#>>>
+# run querying federation setup tests
+# these require other, federated sites to have run test-local-federation
+
+#<<<
+.PHONY: test-querying-federation
+test-querying-federation:
+	mkdir -p tmp/test
+	python ./settings.py
+	source ./env.sh; pytest -v --color=yes ./etc/tests/federation -k "all or querying_site" $(ARGS) --report-log=./tmp/test/test-federation_$(shell date +"%Y-%m-%d_%Hh%Mm%Ss").jsonl
+
 # stop all docker containers
 .PHONY: stop-all
 stop-all:

--- a/Makefile
+++ b/Makefile
@@ -540,9 +540,9 @@ test-integration:
 	mkdir -p tmp/test
 	python ./settings.py
 ifeq ($(KEEP_TEST_DATA),true)
-	source ./env.sh; pytest -v --color=yes ./etc/tests -k 'not test_clean_up' $(ARGS) --report-log=./tmp/test/test-integration_$(shell date +"%Y-%m-%d_%Hh%Mm%Ss").jsonl
+	source ./env.sh; pytest -v --color=yes ./etc/tests/integration -k 'not test_clean_up' $(ARGS) --report-log=./tmp/test/test-integration_$(shell date +"%Y-%m-%d_%Hh%Mm%Ss").jsonl
 else
-	source ./env.sh; pytest -v --color=yes ./etc/tests $(ARGS) --report-log=./tmp/test/test-integration_$(shell date +"%Y-%m-%d_%Hh%Mm%Ss").jsonl
+	source ./env.sh; pytest -v --color=yes ./etc/tests/integration $(ARGS) --report-log=./tmp/test/test-integration_$(shell date +"%Y-%m-%d_%Hh%Mm%Ss").jsonl
 endif
 
 # Run a single test by using its name and print out results whether failing or passing

--- a/auto_federate.py
+++ b/auto_federate.py
@@ -24,26 +24,31 @@ federation_re = r'```federate (.+)```'  # Find messages about federation
 url_re = r'<(.+)>'  # URLs from Slack always end up enclosed in <>s
 for message in messages:
     match = re.match(federation_re, message['text'])
-    if match:
-        groups = match.group(1).split('|')
+    try:
+        if match:
+            groups = match.group(1).split('|')
 
-        # For ease of understanding
-        token = groups[0]
-        name = groups[1]
-        url = re.match(url_re, groups[2]).group(1)
-        client_id = groups[3]
-        province = groups[4]
-        province_code = groups[5]
-        server_id = groups[6]
-        keycloak_url = re.match(url_re, groups[7]).group(1)
+            # For ease of understanding
+            token = groups[0]
+            name = groups[1]
+            url = re.match(url_re, groups[2]).group(1)
+            client_id = groups[3]
+            province = groups[4]
+            province_code = groups[5]
+            server_id = groups[6]
+            keycloak_url = re.match(url_re, groups[7]).group(1)
 
-        # Don't overwrite our own federation
-        if os.environ['FEDERATION_SELF_SERVER_ID'] == server_id:
-                continue
+            # Don't overwrite our own federation
+            if os.environ['FEDERATION_SELF_SERVER_ID'] == server_id:
+                    continue
 
-        # Actually add the server
-        add_federated_server(token, server_id, url, keycloak_url, server_id, province,
-                province_code, verbose=False)
+            # Actually add the server
+            add_federated_server(token, server_id, url, keycloak_url, server_id, province,
+                    province_code, verbose=False)
+    except:
+        # Don't bother if we're trying to add a server but it doesn't look right
+        # This is probably just another user saying something
+        pass
 
 # Check the federation
 site_token = get_site_admin_token()

--- a/etc/tests/federation/test_federation.py
+++ b/etc/tests/federation/test_federation.py
@@ -15,15 +15,45 @@ from site_admin_token import get_site_admin_token
 ENV = get_env()
 
 def test_get_token():
+    """
+    Test to see if the local site admin token can be obtained.
+
+    Raises:
+        AssertionError: If token request fails
+    """
     assert get_site_admin_token()
 
 def make_fanout(headers, body):
+    """
+    Make a fanout call to the local Federation.
+
+    Args:
+        headers: Headers (usually must include an access token)
+        body: Body to call with (see federation.yaml in the Federation microservice for details)
+
+    Returns:
+        A Requests object with the response
+    """
     return requests.post(
         f"{ENV['CANDIG_URL']}/federation/v1/fanout", headers=headers, json=body, timeout=10
     )
 
-## Can we get an access token for a user?
 def get_token(username=None, password=None, access_token=False, realm=ENV['KEYCLOAK_REALM']):
+    """
+    Get a token from Keycloak for a user.
+
+    Args:
+        username: Username to get token for
+        password: Password for the user
+        access_token: If True, return access token instead of refresh token
+        realm: Keycloak realm to authenticate against (defaults to ENV['KEYCLOAK_REALM'])
+
+    Returns:
+        str: Either the refresh token (default) or access token if access_token=True
+
+    Raises:
+        AssertionError: If token request fails
+    """
     payload = {
         "client_id": ENV["CANDIG_CLIENT_ID"],
         "client_secret": ENV["CANDIG_CLIENT_SECRET"],
@@ -44,8 +74,13 @@ def get_token(username=None, password=None, access_token=False, realm=ENV['KEYCL
     return response.json()["refresh_token"]
 
 
-## Service info test: can we get a response from Tyk for all of our services?
 def test_service_info():
+    """
+    Test whether we can get a response from Federation for all of our services.
+
+    Raises:
+        AssertionError: If any of the services are unavailable
+    """
     modules = ENV['CANDIG_ENV']['CANDIG_MODULES'].split(" ")
     headers = {
         "Authorization": f"Bearer {get_site_admin_token()}"
@@ -55,10 +90,7 @@ def test_service_info():
         "htsget": f"ga4gh/drs/v1/service-info",
         "katsu": f"v3/service-info",
         # "rnaget": f"service-info",
-        # "federation": f"v1/service-info",
-        # "opa": f"v1/data/service/service-info",
         "query": f"service-info",
-        # "candig-ingest": f"service-info",
     }
     responses = []
     for module in modules:
@@ -97,7 +129,7 @@ def test_service_info():
 
 def create_keycloak_user(username, password, email, first_name, last_name):
     """
-    Create a user in Keycloak directly using the admin API.
+    Create a user in Keycloak directly using the Keycloak CLI.
     
     Args:
         username (str): The username for the new user
@@ -107,7 +139,7 @@ def create_keycloak_user(username, password, email, first_name, last_name):
         last_name (str): The last name of the user
     
     Returns:
-        dict: The response from the Keycloak API
+        None
     """
     # Step 1: Get Keycloak admin token
     with open(f"{REPO_DIR}/tmp/keycloak/admin-password") as f:
@@ -149,8 +181,17 @@ def create_keycloak_user(username, password, email, first_name, last_name):
     assert run.returncode == 0, "Could not change password for the new user with Keycloak admin"
 
 
-# Need to call this from the other server somehow?
 def approve_user_into_candig(username, password):
+    """
+    Approve a user into the local CanDIG instance by preapproving them and having them request access.
+
+    Args:
+        username (str): The username of the user to approve
+        password (str): The password of the user to approve
+
+    Raises:
+        AssertionError: If any step of the approval process fails
+    """
     # Step 1: preapprove user
     headers = {
         "Authorization": f"Bearer {get_site_admin_token()}"
@@ -176,6 +217,7 @@ def approve_user_into_candig(username, password):
     response = requests.get(
         f"{ENV['CANDIG_ENV']['QUERY_INTERNAL_URL']}/discovery/programs", headers=headers)
     assert response.status_code == 200, f"User {username} went through approval but did not succeed: {response.text}"
+
 
 #### RUN ONLY AT TARGET SITE
 

--- a/etc/tests/federation/test_federation.py
+++ b/etc/tests/federation/test_federation.py
@@ -219,6 +219,15 @@ def approve_user_into_candig(username, password):
     assert response.status_code == 200, f"User {username} went through approval but did not succeed: {response.text}"
 
 
+def test_unauthorized_user(username, password):
+    # Ensure that we cannot access the frontend
+    headers = {
+        "Authorization": f"Bearer {get_token(username, password, True)}"
+    }
+    response = requests.get(f"{ENV['CANDIG_URL']}/ingest/user/me", headers=headers)
+    assert response == 404, f"User {username} can access the frontend without being authorized"
+
+
 #### RUN ONLY AT TARGET SITE
 
 def test_ingest_local_test_dataset():
@@ -233,7 +242,7 @@ def test_ingest_local_test_dataset():
     test_program = {
         "program_id": "TEST_FEDERATE",
         "program_curators": [],
-        "team_members": ["user3@test.ca"]
+        "team_members": ["federated@test.ca"]
     }
 
     # Add the program
@@ -266,18 +275,23 @@ def test_ingest_local_test_dataset():
 
 def test_create_federated_user():
     create_keycloak_user("federated@test.ca", "testfederation", "federated@test.ca", "federated", "test")
+    test_unauthorized_user("federated@test.ca", "testfederation")
     approve_user_into_candig("federated@test.ca", "testfederation")
 
 
 def test_create_unfederated_curator():
     create_keycloak_user("unfederated@test.ca", "testfederation", "unfederated@test.ca", "unfederated", "test")
+    test_unauthorized_user("unfederated@test.ca", "testfederation")
     approve_user_into_candig("unfederated@test.ca", "testfederation")
 
 
 def test_query_authorized_remote_test_dataset():
-    # Get user3@test.ca token
+    """
+    Test querying the TEST_FEDERATE dataset with a user that should have access, seeing whether or not we can access it
+    """
+    # Get token for 'federated@test.ca' user
     headers = {
-        "Authorization": f"Bearer {get_token('user3@test.ca', 'testfederation')}"
+        "Authorization": f"Bearer {get_token('federated@test.ca', 'testfederation')}"
     }
     # Step 1: can we do a discovery query successfully to all sites?
     body = {
@@ -327,9 +341,12 @@ def test_query_authorized_remote_test_dataset():
 
 
 def test_query_unauthorized_remote_test_dataset():
-    # Get user4@test.ca token
+    """
+    Test querying the TEST_FEDERATE dataset with a user that should not have access, seeing whether or not we can access it
+    """
+    # Get unfederated@test.ca token
     headers = {
-        "Authorization": f"Bearer {get_token('user4@test.ca', 'testfederation')}"
+        "Authorization": f"Bearer {get_token('unfederated@test.ca', 'testfederation')}"
     }
 
     # Step 1: can we do a discovery query successfully to all sites?
@@ -374,5 +391,8 @@ def test_query_unauthorized_remote_test_dataset():
         print(r)
         for server in r:
             assert server["status"] == 200, f"Server {server['location']['name']} failed with: {server['message']}"
+
+            # Ensure that we do not have access to this dataset
+            assert len(server["results"]["results"]) == 0, f"Server {server['location']['name']} improperly authorized unfederated@test.ca"
     except requests.JSONDecodeError:
         assert False, f"Invalid JSON response: {response.text}"

--- a/etc/tests/federation/test_federation.py
+++ b/etc/tests/federation/test_federation.py
@@ -219,7 +219,7 @@ def approve_user_into_candig(username, password):
     assert response.status_code == 200, f"User {username} went through approval but did not succeed: {response.text}"
 
 
-def test_unauthorized_user(username, password):
+def check_unauthorized_user(username, password):
     # Ensure that we cannot access the frontend
     headers = {
         "Authorization": f"Bearer {get_token(username, password, True)}"
@@ -275,13 +275,13 @@ def test_ingest_local_test_dataset():
 
 def test_create_federated_user():
     create_keycloak_user("federated@test.ca", "testfederation", "federated@test.ca", "federated", "test")
-    test_unauthorized_user("federated@test.ca", "testfederation")
+    check_unauthorized_user("federated@test.ca", "testfederation")
     approve_user_into_candig("federated@test.ca", "testfederation")
 
 
 def test_create_unfederated_curator():
     create_keycloak_user("unfederated@test.ca", "testfederation", "unfederated@test.ca", "unfederated", "test")
-    test_unauthorized_user("unfederated@test.ca", "testfederation")
+    check_unauthorized_user("unfederated@test.ca", "testfederation")
     approve_user_into_candig("unfederated@test.ca", "testfederation")
 
 

--- a/etc/tests/federation/test_federation.py
+++ b/etc/tests/federation/test_federation.py
@@ -6,7 +6,7 @@ import requests
 import subprocess
 import sys
 
-REPO_DIR = os.path.abspath(f"{os.path.dirname(os.path.realpath(__file__))}/../..")
+REPO_DIR = os.path.abspath(f"{os.path.dirname(os.path.realpath(__file__))}/../../..")
 sys.path.insert(0, os.path.abspath(f"{REPO_DIR}"))
 
 from settings import get_env

--- a/etc/tests/federation/test_federation.py
+++ b/etc/tests/federation/test_federation.py
@@ -67,7 +67,7 @@ def get_token(username=None, password=None, access_token=False, realm=ENV['KEYCL
         data=payload,
     )
 
-    assert response.status_code == 200, f"Getting token for {username} failed with: {response.text}"
+    assert response.ok, f"Getting token for {username} failed with: {response.text}"
 
     if access_token:
         return response.json()["access_token"]
@@ -201,7 +201,7 @@ def approve_user_into_candig(username, password):
     response = requests.post(
         preapproval_url, headers=headers, json=body, timeout=10
     )
-    assert response.status_code == 200, f"Preapproval to {preapproval_url} failed with: {response.text}"
+    assert response.ok, f"Preapproval to {preapproval_url} failed with: {response.text}"
 
     # Step 2: request approval via user
     headers = {
@@ -211,12 +211,12 @@ def approve_user_into_candig(username, password):
     response = requests.post(
         request_url, headers=headers, timeout=10
     )
-    assert response.status_code == 200, f"Requesting user {username} approval failed with: {response.text}"
+    assert response.ok, f"Requesting user {username} approval failed with: {response.text}"
 
     # Step 3: check that requests are ok
     response = requests.get(
         f"{ENV['CANDIG_ENV']['QUERY_INTERNAL_URL']}/discovery/programs", headers=headers)
-    assert response.status_code == 200, f"User {username} went through approval but did not succeed: {response.text}"
+    assert response.ok, f"User {username} went through approval but did not succeed: {response.text}"
 
 
 def check_unauthorized_user(username, password):
@@ -251,7 +251,7 @@ def test_ingest_local_test_dataset():
         headers=headers,
         json=test_program
     )
-    assert response.status_code == 200
+    assert response.ok
 
     # Load the test data file
     data_file = f"{REPO_DIR}/lib/candig-ingest/candigv2-ingest/tests/{ENV['CANDIG_ENV']['CANDIG_SITE_LOCATION']}-SYNTH_01.json"
@@ -268,7 +268,7 @@ def test_ingest_local_test_dataset():
         headers=headers,
         json=ingest_data
     )
-    assert response.status_code == 200
+    assert response.ok
 
 
 ### RUN ONLY ON QUERYING SITE
@@ -303,7 +303,7 @@ def test_query_authorized_remote_test_dataset():
     response = make_fanout(headers, body)
     
     # Verify response
-    assert response.status_code == 200, f"Query discovery endpoint failed with: {response.text}"
+    assert response.ok, f"Query discovery endpoint failed with: {response.text}"
     
     programs = set(())
     try:
@@ -329,7 +329,7 @@ def test_query_authorized_remote_test_dataset():
     response = make_fanout(headers, body)
     
     # Verify response
-    assert response.status_code == 200, f"Query authorized failed with: {response.text}"
+    assert response.ok, f"Query authorized failed with: {response.text}"
     try:
         r = response.json()
         print(r)
@@ -359,7 +359,7 @@ def test_query_unauthorized_remote_test_dataset():
     response = make_fanout(headers, body)
     
     # Verify response
-    assert response.status_code == 200, f"Query discovery endpoint failed with: {response.text}"
+    assert response.ok, f"Query discovery endpoint failed with: {response.text}"
     
     programs = set(())
     try:
@@ -385,7 +385,7 @@ def test_query_unauthorized_remote_test_dataset():
     response = make_fanout(headers, body)
     
     # Verify response
-    assert response.status_code == 200, f"Query authorized failed with: {response.text}"
+    assert response.ok, f"Query authorized failed with: {response.text}"
     try:
         r = response.json()
         print(r)

--- a/etc/tests/federation/test_federation.py
+++ b/etc/tests/federation/test_federation.py
@@ -171,7 +171,7 @@ def create_keycloak_user(username, password, email, first_name, last_name):
     assert run.returncode == 0, "Could not login as admin for into Keycloak"
     # b. create the user
     run = subprocess.run(["docker", "exec", container_name, "/opt/keycloak/bin/kcadm.sh",
-                   "create", "users", "-r", ENV["KEYCLOAK_REALM"], "-s", f"username=\"{username}\"",
+                   "create", "users", "-r", ENV["KEYCLOAK_REALM"], "-s", f"username=\"{username}\"", "-s", "enabled=true",
                    "-s", f"email=\"{email}\"", "-s", f"firstName=\"{first_name}\"", "-s", f"lastName=\"{last_name}\""])
     assert run.returncode == 0, "Could not create user with the admin Keycloak session"
     # c. set their password --username "$USERNAME" --new-password "$PASSWORD"

--- a/etc/tests/federation/test_federation.py
+++ b/etc/tests/federation/test_federation.py
@@ -335,7 +335,10 @@ def test_querying_site_query_authorized_remote_test_dataset():
         print(r)
         for server in r:
             assert server["status"] == 200, f"Server {server['location']['name']} failed with: {server['message']}"
-            assert server["results"]["count"] == 24, f"Server {server['location']['name']} had a strange number of results in query"
+            # NB: I do not currently ingest the federated dataset at the same location that the querying tests are run from
+            # There is no reason for this to be the case, other than for speed's sake. Thus, the local server will not have anything here
+            if server['location']['name'] != 'LOCAL':
+                assert server["results"]["count"] == 24, f"Server {server['location']['name']} had a strange number of results in query"
     except requests.JSONDecodeError:
         assert False, f"Invalid JSON response: {response.text}"
 

--- a/etc/tests/federation/test_federation.py
+++ b/etc/tests/federation/test_federation.py
@@ -14,7 +14,7 @@ from site_admin_token import get_site_admin_token
 
 ENV = get_env()
 
-def test_get_token():
+def test_all_get_token():
     """
     Test to see if the local site admin token can be obtained.
 
@@ -74,7 +74,7 @@ def get_token(username=None, password=None, access_token=False, realm=ENV['KEYCL
     return response.json()["refresh_token"]
 
 
-def test_service_info():
+def test_all_service_info():
     """
     Test whether we can get a response from Federation for all of our services.
 
@@ -273,19 +273,19 @@ def test_ingest_local_test_dataset():
 
 ### RUN ONLY ON QUERYING SITE
 
-def test_create_federated_user():
+def test_querying_site_create_federated_user():
     create_keycloak_user("federated@test.ca", "testfederation", "federated@test.ca", "federated", "test")
     check_unauthorized_user("federated@test.ca", "testfederation")
     approve_user_into_candig("federated@test.ca", "testfederation")
 
 
-def test_create_unfederated_curator():
+def test_querying_site__unfederated_curator():
     create_keycloak_user("unfederated@test.ca", "testfederation", "unfederated@test.ca", "unfederated", "test")
     check_unauthorized_user("unfederated@test.ca", "testfederation")
     approve_user_into_candig("unfederated@test.ca", "testfederation")
 
 
-def test_query_authorized_remote_test_dataset():
+def test_querying_site_query_authorized_remote_test_dataset():
     """
     Test querying the TEST_FEDERATE dataset with a user that should have access, seeing whether or not we can access it
     """
@@ -340,7 +340,7 @@ def test_query_authorized_remote_test_dataset():
         assert False, f"Invalid JSON response: {response.text}"
 
 
-def test_query_unauthorized_remote_test_dataset():
+def test_querying_site_query_unauthorized_remote_test_dataset():
     """
     Test querying the TEST_FEDERATE dataset with a user that should not have access, seeing whether or not we can access it
     """

--- a/etc/tests/federation/test_federation.py
+++ b/etc/tests/federation/test_federation.py
@@ -225,7 +225,7 @@ def check_unauthorized_user(username, password):
         "Authorization": f"Bearer {get_token(username, password, True)}"
     }
     response = requests.get(f"{ENV['CANDIG_URL']}/ingest/user/me", headers=headers)
-    assert response == 404, f"User {username} can access the frontend without being authorized"
+    assert response.status_code == 404, f"User {username} can access the frontend without being authorized"
 
 
 #### RUN ONLY AT TARGET SITE

--- a/etc/tests/integration/test_integration.py
+++ b/etc/tests/integration/test_integration.py
@@ -12,7 +12,7 @@ import pprint
 import time
 import authx.auth
 
-REPO_DIR = os.path.abspath(f"{os.path.dirname(os.path.realpath(__file__))}/../..")
+REPO_DIR = os.path.abspath(f"{os.path.dirname(os.path.realpath(__file__))}/../../..")
 sys.path.insert(0, os.path.abspath(f"{REPO_DIR}"))
 
 from settings import get_env

--- a/etc/tests/test_federation.py
+++ b/etc/tests/test_federation.py
@@ -1,0 +1,235 @@
+import json
+import os
+import pytest
+import requests
+import sys
+
+REPO_DIR = os.path.abspath(f"{os.path.dirname(os.path.realpath(__file__))}/../..")
+sys.path.insert(0, os.path.abspath(f"{REPO_DIR}"))
+
+from settings import get_env
+from site_admin_token import get_site_admin_token
+
+ENV = get_env()
+
+def test_get_token():
+    assert get_site_admin_token()
+
+def make_fanout(headers, body):
+    return requests.post(
+        f"{ENV['CANDIG_URL']}/federation/v1/fanout", headers=headers, json=body, timeout=10
+    )
+
+## Can we get an access token for a user?
+def get_token(username=None, password=None, access_token=False):
+    payload = {
+        "client_id": ENV["CANDIG_CLIENT_ID"],
+        "client_secret": ENV["CANDIG_CLIENT_SECRET"],
+        "grant_type": "password",
+        "username": username,
+        "password": password,
+        "scope": "openid",
+    }
+    response = requests.post(
+        f"{ENV['KEYCLOAK_PUBLIC_URL']}/auth/realms/{ENV['KEYCLOAK_REALM']}/protocol/openid-connect/token",
+        data=payload,
+    )
+    if response.status_code == 200:
+        if access_token:
+            return response.json()["access_token"]
+        return response.json()["refresh_token"]
+
+
+## Service info test: can we get a response from Tyk for all of our services?
+def test_service_info():
+    modules = ENV['CANDIG_ENV']['CANDIG_MODULES'].split(" ")
+    headers = {
+        "Authorization": f"Bearer {get_site_admin_token()}"
+    }
+    endpoints = {
+        # all of these endpoints should return JSON
+        "htsget": f"ga4gh/drs/v1/service-info",
+        "katsu": f"v3/service-info",
+        # "rnaget": f"service-info",
+        # "federation": f"v1/service-info",
+        # "opa": f"v1/data/service/service-info",
+        "query": f"service-info",
+        # "candig-ingest": f"service-info",
+    }
+    responses = []
+    for module in modules:
+        if module in endpoints:
+            endpoint = endpoints[module]
+            body = {
+                "method": "GET",
+                "path": endpoint,
+                "payload": {},
+                "service": module
+            }
+            response = make_fanout(headers, body)
+            # Three things to catch:
+            # 1: The entire request failed
+            status_code = response.status_code
+            if status_code != 200:
+                print(f"Entire request failed: {status_code} {response.text}")
+                continue
+
+            # 2: A particular server errored out
+            servers_ok = {}
+            try:
+                r = response.json()
+                for server in r:
+                    if server["status"] != 200:
+                        servers_ok[server["location"]["name"]] = server["message"]
+                    else:
+                        servers_ok[server["location"]["name"]] = "ok"
+                responses.append(servers_ok)
+            except requests.JSONDecodeError as e:
+                status_code = 500
+                responses.append("Entire request failed: " + response.text)
+            print(f"{module}: {status_code}")
+    assert all(response[server] == "ok" for response in responses for server in response)
+
+
+# Need to call this from the other server somehow?
+def test_preapprove_user():
+    headers = {
+        "Authorization": f"Bearer {get_site_admin_token()}"
+    }
+    body = ["user3@test.ca"]
+    preapproval_url = f"{ENV['CANDIG_URL']}/ingest/user/preapproved"
+    response = requests.post(
+        preapproval_url, headers=headers, json=body, timeout=10
+    )
+    assert response.status_code == 200, f"Preapproval to {preapproval_url} failed with: {response.text}"
+
+
+def test_query_endpoint():
+    # Create user3@test.ca (should be preapproved)
+    # create_keycloak_user("user3@test.ca", "testfederation", "user3@test.ca", "user3", "test")
+
+    # Get user3@test.ca token
+    headers = {
+        "Authorization": f"Bearer {get_token('user3@test.ca', 'testfederation')}"
+    }
+
+    # Request authorization
+    response = requests.post(
+        f"{ENV['CANDIG_URL']}/ingest/user/pending/request", headers=headers, timeout=10
+    )
+    assert response.status_code == 200, f"Could not request authorization: {response.status_code} {response.text}"
+
+    # Test query endpoint
+    body = {
+        "method": "GET", 
+        "path": "query",
+        "payload": {},
+        "service": "query"
+    }
+    response = make_fanout(headers, body)
+    
+    # Verify response
+    assert response.status_code == 200, f"Query endpoint failed with: {response.text}"
+    
+    try:
+        r = response.json()
+        for server in r:
+            assert server["status"] == 200, f"Server {server['location']['name']} failed with: {server['message']}"
+    except requests.JSONDecodeError:
+        assert False, f"Invalid JSON response: {response.text}"
+
+def create_keycloak_user(username, password, email, first_name, last_name):
+    """
+    Create a user in Keycloak directly using the admin API.
+    
+    Args:
+        username (str): The username for the new user
+        password (str): The password for the new user
+        email (str): The email address for the new user
+        first_name (str): The first name of the user
+        last_name (str): The last name of the user
+    
+    Returns:
+        dict: The response from the Keycloak API
+    """
+    # Step 1: Get admin token
+    admin_token = get_site_admin_token()
+    
+    # Step 2: Create user
+    users_url = f"{ENV["KEYCLOAK_PUBLIC_URL"]}/auth/admin/realms/{ENV["KEYCLOAK_REALM"]}/users"
+    headers = {
+        "Authorization": f"Bearer {admin_token}",
+        "Content-Type": "application/json"
+    }
+    
+    user_data = {
+        "username": username,
+        "enabled": True,
+        "email": email,
+        "firstName": first_name,
+        "lastName": last_name,
+        "credentials": [
+            {
+                "type": "password",
+                "value": password,
+                "temporary": False
+            }
+        ]
+    }
+    
+    create_response = requests.post(users_url, headers=headers, json=user_data)
+    if create_response.status_code not in [201, 204]:
+        raise Exception(f"Failed to create user: {create_response.text}")
+    
+    # Get the user ID from the Location header
+    user_id = None
+    if "Location" in create_response.headers:
+        location = create_response.headers["Location"]
+        user_id = location.split("/")[-1]
+    
+    return {
+        "status": "success",
+        "user_id": user_id,
+        "message": f"User {username} created successfully"
+    }
+
+def test_ingest_federated_dataset():
+    # Get admin token for authorization
+    token = get_site_admin_token()
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json; charset=utf-8"
+    }
+
+    # Create program authorization for TEST_FEDERATE
+    test_program = {
+        "program_id": "TEST_FEDERATE",
+        "program_curators": [],
+        "team_members": ["user3@test.ca"]
+    }
+
+    # Add the program
+    response = requests.post(
+        f"{ENV['CANDIG_URL']}/ingest/program",
+        headers=headers,
+        json=test_program
+    )
+    assert response.status_code == 200
+
+    # Load the test data file
+    data_file = f"{REPO_DIR}/lib/candig-ingest/candigv2-ingest/tests/{ENV['CANDIG_ENV']['CANDIG_SITE_LOCATION']}-SYNTH_01.json"
+    with open(data_file) as f:
+        ingest_data = json.load(f)
+
+    # Update the program ID in the data
+    for donor in ingest_data["donors"]:
+        donor["program_id"] = "TEST_FEDERATE"
+
+    # Ingest the dataset
+    response = requests.post(
+        f"{ENV['CANDIG_URL']}/ingest/clinical",
+        headers=headers,
+        json=ingest_data
+    )
+    assert response.status_code == 200
+

--- a/etc/tests/test_federation.py
+++ b/etc/tests/test_federation.py
@@ -1,7 +1,9 @@
 import json
 import os
 import pytest
+import re
 import requests
+import subprocess
 import sys
 
 REPO_DIR = os.path.abspath(f"{os.path.dirname(os.path.realpath(__file__))}/../..")
@@ -21,7 +23,7 @@ def make_fanout(headers, body):
     )
 
 ## Can we get an access token for a user?
-def get_token(username=None, password=None, access_token=False):
+def get_token(username=None, password=None, access_token=False, realm=ENV['KEYCLOAK_REALM']):
     payload = {
         "client_id": ENV["CANDIG_CLIENT_ID"],
         "client_secret": ENV["CANDIG_CLIENT_SECRET"],
@@ -31,13 +33,15 @@ def get_token(username=None, password=None, access_token=False):
         "scope": "openid",
     }
     response = requests.post(
-        f"{ENV['KEYCLOAK_PUBLIC_URL']}/auth/realms/{ENV['KEYCLOAK_REALM']}/protocol/openid-connect/token",
+        f"{ENV['KEYCLOAK_PUBLIC_URL']}/auth/realms/{realm}/protocol/openid-connect/token",
         data=payload,
     )
-    if response.status_code == 200:
-        if access_token:
-            return response.json()["access_token"]
-        return response.json()["refresh_token"]
+
+    assert response.status_code == 200, f"Getting token for {username} failed with: {response.text}"
+
+    if access_token:
+        return response.json()["access_token"]
+    return response.json()["refresh_token"]
 
 
 ## Service info test: can we get a response from Tyk for all of our services?
@@ -91,53 +95,6 @@ def test_service_info():
     assert all(response[server] == "ok" for response in responses for server in response)
 
 
-# Need to call this from the other server somehow?
-def test_preapprove_user():
-    headers = {
-        "Authorization": f"Bearer {get_site_admin_token()}"
-    }
-    body = ["user3@test.ca"]
-    preapproval_url = f"{ENV['CANDIG_URL']}/ingest/user/preapproved"
-    response = requests.post(
-        preapproval_url, headers=headers, json=body, timeout=10
-    )
-    assert response.status_code == 200, f"Preapproval to {preapproval_url} failed with: {response.text}"
-
-
-def test_query_endpoint():
-    # Create user3@test.ca (should be preapproved)
-    # create_keycloak_user("user3@test.ca", "testfederation", "user3@test.ca", "user3", "test")
-
-    # Get user3@test.ca token
-    headers = {
-        "Authorization": f"Bearer {get_token('user3@test.ca', 'testfederation')}"
-    }
-
-    # Request authorization
-    response = requests.post(
-        f"{ENV['CANDIG_URL']}/ingest/user/pending/request", headers=headers, timeout=10
-    )
-    assert response.status_code == 200, f"Could not request authorization: {response.status_code} {response.text}"
-
-    # Test query endpoint
-    body = {
-        "method": "GET", 
-        "path": "query",
-        "payload": {},
-        "service": "query"
-    }
-    response = make_fanout(headers, body)
-    
-    # Verify response
-    assert response.status_code == 200, f"Query endpoint failed with: {response.text}"
-    
-    try:
-        r = response.json()
-        for server in r:
-            assert server["status"] == 200, f"Server {server['location']['name']} failed with: {server['message']}"
-    except requests.JSONDecodeError:
-        assert False, f"Invalid JSON response: {response.text}"
-
 def create_keycloak_user(username, password, email, first_name, last_name):
     """
     Create a user in Keycloak directly using the admin API.
@@ -152,48 +109,77 @@ def create_keycloak_user(username, password, email, first_name, last_name):
     Returns:
         dict: The response from the Keycloak API
     """
-    # Step 1: Get admin token
-    admin_token = get_site_admin_token()
+    # Step 1: Get Keycloak admin token
+    with open(f"{REPO_DIR}/tmp/keycloak/admin-password") as f:
+        admin_pass = f.read()
     
     # Step 2: Create user
-    users_url = f"{ENV["KEYCLOAK_PUBLIC_URL"]}/auth/admin/realms/{ENV["KEYCLOAK_REALM"]}/users"
-    headers = {
-        "Authorization": f"Bearer {admin_token}",
-        "Content-Type": "application/json"
-    }
-    
-    user_data = {
-        "username": username,
-        "enabled": True,
-        "email": email,
-        "firstName": first_name,
-        "lastName": last_name,
-        "credentials": [
-            {
-                "type": "password",
-                "value": password,
-                "temporary": False
-            }
-        ]
-    }
-    
-    create_response = requests.post(users_url, headers=headers, json=user_data)
-    if create_response.status_code not in [201, 204]:
-        raise Exception(f"Failed to create user: {create_response.text}")
-    
-    # Get the user ID from the Location header
-    user_id = None
-    if "Location" in create_response.headers:
-        location = create_response.headers["Location"]
-        user_id = location.split("/")[-1]
-    
-    return {
-        "status": "success",
-        "user_id": user_id,
-        "message": f"User {username} created successfully"
-    }
+    # NB: We can't use the usual OIDC flow to grab an admin token, because we
+    # cannot retrieve the admin token without a client, and don't have one
+    # initially setup. Because of this, we have to go through the command-line
+    # admin tools to create our user
+    # i.e. going through kcadm.sh. We had the code already for this in
+    # keycloak_setup.sh and it's a pain to work with here so...
 
-def test_ingest_federated_dataset():
+    # Find the docker container
+    docker_ps = subprocess.run(["docker", "ps"], capture_output=True)
+    split_docker = docker_ps.stdout.decode('utf8').split("\n")
+    container_name = ""
+    for container in split_docker:
+        if re.search(r"keycloak\/keycloak", container):
+            container_name = container.split()[-1]
+    
+    assert container_name != "", "Coult not find the keycloak/keycloak container"
+
+    # Run the commands to create the user
+    # a. login as admin
+    run = subprocess.run(["docker", "exec", container_name, "/opt/keycloak/bin/kcadm.sh",
+                   "config", "credentials", "--server", f"{ENV["KEYCLOAK_PUBLIC_URL"]}/auth",
+                   "--user", "admin", "--password", admin_pass, "--realm", "master"])
+    assert run.returncode == 0, "Could not login as admin for into Keycloak"
+    # b. create the user
+    run = subprocess.run(["docker", "exec", container_name, "/opt/keycloak/bin/kcadm.sh",
+                   "create", "users", "-r", ENV["KEYCLOAK_REALM"], "-s", f"username=\"{username}\"",
+                   "-s", f"email=\"{email}\"", "-s", f"firstName=\"{first_name}\"", "-s", f"lastName=\"{last_name}\""])
+    assert run.returncode == 0, "Could not create user with the admin Keycloak session"
+    # c. set their password --username "$USERNAME" --new-password "$PASSWORD"
+    run = subprocess.run(["docker", "exec", container_name, "/opt/keycloak/bin/kcadm.sh",
+                   "set-password", "-r", ENV["KEYCLOAK_REALM"], "--username", username,
+                   "--new-password", password])
+    assert run.returncode == 0, "Could not change password for the new user with Keycloak admin"
+
+
+# Need to call this from the other server somehow?
+def approve_user_into_candig(username, password):
+    # Step 1: preapprove user
+    headers = {
+        "Authorization": f"Bearer {get_site_admin_token()}"
+    }
+    body = [username]
+    preapproval_url = f"{ENV['CANDIG_URL']}/ingest/user/preapproved"
+    response = requests.post(
+        preapproval_url, headers=headers, json=body, timeout=10
+    )
+    assert response.status_code == 200, f"Preapproval to {preapproval_url} failed with: {response.text}"
+
+    # Step 2: request approval via user
+    headers = {
+        "Authorization": f"Bearer {get_token(username, password, True)}"
+    }
+    request_url = f"{ENV['CANDIG_URL']}/ingest/user/pending/request"
+    response = requests.post(
+        request_url, headers=headers, timeout=10
+    )
+    assert response.status_code == 200, f"Requesting user {username} approval failed with: {response.text}"
+
+    # Step 3: check that requests are ok
+    response = requests.get(
+        f"{ENV['CANDIG_ENV']['QUERY_INTERNAL_URL']}/discovery/programs", headers=headers)
+    assert response.status_code == 200, f"User {username} went through approval but did not succeed: {response.text}"
+
+#### RUN ONLY AT TARGET SITE
+
+def test_ingest_local_test_dataset():
     # Get admin token for authorization
     token = get_site_admin_token()
     headers = {
@@ -233,3 +219,118 @@ def test_ingest_federated_dataset():
     )
     assert response.status_code == 200
 
+
+### RUN ONLY ON QUERYING SITE
+
+def test_create_federated_user():
+    create_keycloak_user("federated@test.ca", "testfederation", "federated@test.ca", "federated", "test")
+    approve_user_into_candig("federated@test.ca", "testfederation")
+
+
+def test_create_unfederated_curator():
+    create_keycloak_user("unfederated@test.ca", "testfederation", "unfederated@test.ca", "unfederated", "test")
+    approve_user_into_candig("unfederated@test.ca", "testfederation")
+
+
+def test_query_authorized_remote_test_dataset():
+    # Get user3@test.ca token
+    headers = {
+        "Authorization": f"Bearer {get_token('user3@test.ca', 'testfederation')}"
+    }
+    # Step 1: can we do a discovery query successfully to all sites?
+    body = {
+        "method": "GET", 
+        "path": "discovery/programs",
+        "payload": {},
+        "service": "query"
+    }
+    response = make_fanout(headers, body)
+    
+    # Verify response
+    assert response.status_code == 200, f"Query discovery endpoint failed with: {response.text}"
+    
+    programs = set(())
+    try:
+        r = response.json()
+        print(r)
+        for server in r:
+            assert server["status"] == 200, f"Server {server['location']['name']} failed with: {server['message']}"
+            for program in server['results']['programs']:
+                programs |= {program['program_id']}
+            # TODO: Check that the result is sane
+        # assert len(r) > 1, f"Only one server found? This is not a federated environment"
+    except requests.JSONDecodeError:
+        assert False, f"Invalid JSON response: {response.text}"
+
+    # Step 2: can we do a query and grab responses (only include the ones from the TEST_FEDERATE set)
+    programs -= {"TEST_FEDERATE"}
+    body = {
+        "method": "GET", 
+        "path": "query",
+        "payload": {"exclude_programs": ",".join(programs)},
+        "service": "query"
+    }
+    response = make_fanout(headers, body)
+    
+    # Verify response
+    assert response.status_code == 200, f"Query authorized failed with: {response.text}"
+    try:
+        r = response.json()
+        print(r)
+        for server in r:
+            assert server["status"] == 200, f"Server {server['location']['name']} failed with: {server['message']}"
+            assert server["results"]["count"] == 24, f"Server {server['location']['name']} had a strange number of results in query"
+    except requests.JSONDecodeError:
+        assert False, f"Invalid JSON response: {response.text}"
+
+
+def test_query_unauthorized_remote_test_dataset():
+    # Get user4@test.ca token
+    headers = {
+        "Authorization": f"Bearer {get_token('user4@test.ca', 'testfederation')}"
+    }
+
+    # Step 1: can we do a discovery query successfully to all sites?
+    body = {
+        "method": "GET", 
+        "path": "discovery/programs",
+        "payload": {},
+        "service": "query"
+    }
+    response = make_fanout(headers, body)
+    
+    # Verify response
+    assert response.status_code == 200, f"Query discovery endpoint failed with: {response.text}"
+    
+    programs = set(())
+    try:
+        r = response.json()
+        print(r)
+        for server in r:
+            assert server["status"] == 200, f"Server {server['location']['name']} failed with: {server['message']}"
+            for program in server['results']['programs']:
+                programs |= {program['program_id']}
+            # TODO: Check that the result is sane
+        # assert len(r) > 1, f"Only one server found? This is not a federated environment"
+    except requests.JSONDecodeError:
+        assert False, f"Invalid JSON response: {response.text}"
+
+    # Step 2: can we do a query and fail to grab responses (only include the ones from the TEST_FEDERATE set)
+    programs -= {"TEST_FEDERATE"}
+    body = {
+        "method": "GET", 
+        "path": "query",
+        "payload": {"exclude_programs": ",".join(programs)},
+        "service": "query"
+    }
+    response = make_fanout(headers, body)
+    
+    # Verify response
+    assert response.status_code == 200, f"Query authorized failed with: {response.text}"
+    try:
+        r = response.json()
+        print(r)
+        for server in r:
+            assert server["status"] == 200, f"Server {server['location']['name']} failed with: {server['message']}"
+    except requests.JSONDecodeError:
+        assert False, f"Invalid JSON response: {response.text}"

--- a/nightly_build.sh
+++ b/nightly_build.sh
@@ -65,7 +65,7 @@ TYK_TESTS=""
 TRIES=0
 while [ -z "$TYK_TESTS" ];
 do
-    TYK_TESTS=$(make test-integration ARGS='-k "test_tyk" etc/tests/test_integration.py' | grep "1 passed")
+    TYK_TESTS=$(make test-integration ARGS='-k "test_tyk" etc/tests/integration/test_integration.py' | grep "1 passed")
     sleep 15
     TRIES=$TRIES+1
     if [[ $TRIES -gt 120 ]]; then

--- a/nightly_federation_test.sh
+++ b/nightly_federation_test.sh
@@ -20,5 +20,5 @@ if [ $LOCAL_FEDERATION -eq 1 ]; then
     make test-local-federation
 else
     make test-querying-federation ARGS="--color=no" >tmp/federation-test.txt 2<&1
-    PostToSlack "Federation tests:\n\`\`\`$(tail tmp/federation-test.txt)\`\`\`"
+    PostToSlack "Federation tests:\n\`\`\`$(tail -c 100 tmp/federation-test.txt)\`\`\`"
 fi

--- a/nightly_federation_test.sh
+++ b/nightly_federation_test.sh
@@ -20,5 +20,9 @@ if [ $LOCAL_FEDERATION -eq 1 ]; then
     make test-local-federation
 else
     make test-querying-federation ARGS="--color=no" >tmp/federation-test.txt 2<&1
-    PostToSlack "Federation tests:\n\`\`\`$(tail -c 100 tmp/federation-test.txt)\`\`\`"
+    if [ $? - ne 0 ]; then
+        PostToSlack "Federation tests:\n\`\`\`$(tail -c 300 tmp/federation-test.txt)\`\`\`"
+    else
+        PostToSlack "Federation tests succeeded"
+    fi
 fi

--- a/nightly_federation_test.sh
+++ b/nightly_federation_test.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+PostToSlack () {
+    # Single quoting the string breaks formatting, so instead we rely on the \" -> \\" to make sure this doesn't break the curl
+    # SAFE_TEXT=${1@Q}
+    SAFE_TEXT=${1//\"/\\\"}
+    echo $SAFE_TEXT
+    curl -X POST -H 'Content-type: application/json' --data "{\"text\":\"$SAFE_TEXT\"}" $HOOK_URL
+}
+
+# Make sure all of our necessary configuration works
+source nightly_env.sh
+if [ -z "$HOOK_URL" ] || [ -z "$BOT_TOKEN" ]; then
+    echo "Nightly build cannot work without the following settings set: \$HOOK_URL and \$BOT_TOKEN"
+    exit
+fi
+
+# Attempt to run the nightly federation, depending on what we do
+if [[ $LOCAL_FEDERATION -eq 1]]; then
+    make test-local-federation
+else
+    make test-querying-federation ARGS="--color=no" >tmp/federation-test.txt 2<&1
+    PostToSlack "Federation tests:\n\`\`\`$(tail tmp/federation-test.txt)\`\`\`"
+fi

--- a/nightly_federation_test.sh
+++ b/nightly_federation_test.sh
@@ -16,7 +16,7 @@ if [ -z "$HOOK_URL" ] || [ -z "$BOT_TOKEN" ]; then
 fi
 
 # Attempt to run the nightly federation, depending on what we do
-if [[ $LOCAL_FEDERATION -eq 1]]; then
+if [ $LOCAL_FEDERATION -eq 1 ]; then
     make test-local-federation
 else
     make test-querying-federation ARGS="--color=no" >tmp/federation-test.txt 2<&1

--- a/nightly_federation_test.sh
+++ b/nightly_federation_test.sh
@@ -5,7 +5,7 @@ PostToSlack () {
     # SAFE_TEXT=${1@Q}
     SAFE_TEXT=${1//\"/\\\"}
     echo $SAFE_TEXT
-    curl -X POST -H 'Content-type: application/json' --data "{\"text\":\"$SAFE_TEXT\"}" $HOOK_URL
+    # curl -X POST -H 'Content-type: application/json' --data "{\"text\":\"$SAFE_TEXT\"}" $HOOK_URL
 }
 
 # Make sure all of our necessary configuration works

--- a/nightly_federation_test.sh
+++ b/nightly_federation_test.sh
@@ -5,7 +5,7 @@ PostToSlack () {
     # SAFE_TEXT=${1@Q}
     SAFE_TEXT=${1//\"/\\\"}
     echo $SAFE_TEXT
-    # curl -X POST -H 'Content-type: application/json' --data "{\"text\":\"$SAFE_TEXT\"}" $HOOK_URL
+    curl -X POST -H 'Content-type: application/json' --data "{\"text\":\"$SAFE_TEXT\"}" $HOOK_URL
 }
 
 # Make sure all of our necessary configuration works

--- a/settings.py
+++ b/settings.py
@@ -70,6 +70,7 @@ def get_env():
     vars["CANDIG_ENV"] = INTERPOLATED_ENV
     vars["DB_PATH"] = "postgres-db"
     vars["FEDERATION_SELF_SERVER_ID"] = get_env_value("FEDERATION_SELF_SERVER_ID")
+    vars["CANDIG_SITE_LOCATION"] = get_env_value("CANDIG_SITE_LOCATION")
 
     # test users:
     if get_env_value("DEFAULT_SITE_ADMIN_USER") is not None:


### PR DESCRIPTION
# Description
This introduces two new kinds of tests, run under make: `make test-local-federation` and `make test-querying-federation`. One site must run the "local" set of tests, which sets up datasets. The other must run the "querying" tests, which checks permissions on those datasets.

## To Test
There are two servers are UHN that currently use it, `candig-federation-1` and `candig-dev`. They should run nightly build first, then nightly federation, and then these tests. `candig-federation-1` runs its tests first and is setup to be the "local" set of tests that sets up a dataset to be queried by the other server. `candig-dev` is the "querying" server and runs those tests.