### PR TITLE
Bugfix/unremovable conda defaults

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ ifeq ($(VENV_OS), arm64mac)
 	# until you source the script that ships with conda
 	source $(CONDA_ENV_SETTINGS) && $(CONDA) init zsh
 endif
-	$(CONDA) config --remove channels defaults
+	# $(CONDA) config --remove channels defaults
 	$(CONDA) config --add channels conda-forge
 	$(CONDA) config --set channel_priority strict
 

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ ifeq ($(VENV_OS), arm64mac)
 	# until you source the script that ships with conda
 	source $(CONDA_ENV_SETTINGS) && $(CONDA) init zsh
 endif
-	# $(CONDA) config --remove channels defaults
+	-$(CONDA) config --remove channels defaults
 	$(CONDA) config --add channels conda-forge
 	$(CONDA) config --set channel_priority strict
 


### PR DESCRIPTION
# Description
As of last week, the latest version of conda appears to no longer allow you to remove the defaults channel without erroring out, which causes the rest of the `bin-conda` command to fail. Fresh installs will therefore be unable to function. However, I've gotten the build to work without the command, so I've just commented it out here.

# To Test
Reinstall your conda via bin-conda and init-conda under this branch. Instead of erroring out at removing the default channel, it should continue as normal.