### PR TITLE
Make the approle tokens periodic, so that they can be renewed indefinitely

### DIFF
--- a/lib/vault/vault_setup.sh
+++ b/lib/vault/vault_setup.sh
@@ -128,16 +128,16 @@ cidr_block=$(docker network inspect --format "{{json .IPAM.Config}}" candigv2_de
 cidr_block=$(echo ${cidr_block} | tr -d '"')
 cidr_block="${cidr_block}/27"
 if [ $CANDIG_DEBUG_MODE -eq 1 ]; then
-  echo "{}" > lib/vault/tmp/temp.json
+  echo "{\"token_period\": \"768h\"}" > lib/vault/tmp/temp.json
 else
-  echo "{\"bound_cidrs\": [\"${cidr_block}\"]}" > lib/vault/tmp/temp.json
+  echo "{\"bound_cidrs\": [\"${cidr_block}\"], \"token_period\": \"768h\"}" > lib/vault/tmp/temp.json
 fi
 curl --request POST --header "X-Vault-Token: ${key_root}" --data @lib/vault/tmp/temp.json $VAULT_SERVICE_PUBLIC_URL/v1/auth/token/roles/approle
 rm lib/vault/tmp/temp.json
 
 echo
 echo ">> setting up approle token"
-echo "{\"policies\": [\"approle\"]}" > lib/vault/tmp/temp.json
+echo "{\"policies\": [\"approle\"], \"period\": \"768h\"}" > lib/vault/tmp/temp.json
 curl --request POST --header "X-Vault-Token: ${key_root}" --data @lib/vault/tmp/temp.json $VAULT_SERVICE_PUBLIC_URL/v1/auth/token/create/approle | jq '.auth.client_token' -r > tmp/vault/approle-token
 docker cp tmp/vault/approle-token $vault_runner:/vault/config/approle-token
 rm lib/vault/tmp/temp.json


### PR DESCRIPTION
# Background
We've been having issues where the Vault tokens on prod instances will all lapse after about a month. This is likely due to them not renewing, as the approle role didn't specify a maximum period (thus, the max was 0, and the token would only get renewed up to the maximum default by Vault, which is 32 days (768 hours)). Notably, if you intercept the return from `renew_token.sh`'s `curl` renewal, you'll see something like the following:

```{
   "request_id":"26f5888a-0efa-eca3-62ff-1a97d7ff62dd",
   "lease_id":"",
   "renewable":false,
   "lease_duration":0,
   "data":null,
   "wrap_info":null,
   "warnings":[
      "TTL of \"767h59m39s\" exceeded the effective max_ttl of \"767h58m41s\"; TTL value is capped accordingly"
   ],
   "auth":{
      "client_token":"hvs.CAESIFTUo195_x8x_9AjGY5GVJIJdEwW3XXgmJ83y_HfJmPMGh4KHGh2cy5abWE3SkJ2eEZtYWxOMEhzUEFvdTQ5TFY",
      "accessor":"TGLHCYI9iCAnz9KB7MAoCVAi",
      "policies":[
         "approle",
         "default"
      ],
      "token_policies":[
         "approle",
         "default"
      ],
      "metadata":null,
      "lease_duration":2764721,
      "renewable":true,
      "entity_id":"",
      "token_type":"service",
      "orphan":false,
      "mfa_requirement":null,
      "num_uses":0
   }
}
```

Where the maximum TTL would count down to 0 as the server went on.

**Note**: This is only our hypothesis for why prod occasionally fails to renew, but it seems like it lines up with the evidence.

# Notes
- If you intercept the return from the `curl` on line 135, you'll see the following:
```{
   "request_id":"cd720357-fbfd-ba30-12fa-c393374e34a7",
   "lease_id":"",
   "renewable":false,
   "lease_duration":0,
   "data":null,
   "wrap_info":null,
   "warnings":[
      "Period specified both during creation call and in role; using the lesser value of 2764800 seconds"
   ],
   "auth":{
      "client_token":"hvs.CAESILLbtxSZG5wC4ll41zV_kTi9_ws5nQZ2V7Lul23LSMxDGh4KHGh2cy5hQ0x3b210V2tUWVI3eDJrS0lUWjdGQng",
      "accessor":"YL3GS6CrGE4lsgPGeyzWscsE",
      "policies":[
         "approle",
         "default"
      ],
      "token_policies":[
         "approle",
         "default"
      ],
      "metadata":null,
      "lease_duration":2764800,
      "renewable":true,
      "entity_id":"",
      "token_type":"service",
      "orphan":false,
      "mfa_requirement":null,
      "num_uses":0
   }
}
```
The warning is a little confusing to me considering it seems like you _have_ to specify both? If you don't specify it at the role level, you run into the issues that we currently run into (where the resulting token isn't periodic).

- In any case, with this patch applied the `curl` in `renew_token.sh` now returns:
```
{
   "request_id":"96c805bb-fcbd-2ab8-a918-ace06a6f1a47",
   "lease_id":"",
   "renewable":false,
   "lease_duration":0,
   "data":null,
   "wrap_info":null,
   "warnings":null,
   "auth":{
      "client_token":"hvs.CAESILLbtxSZG5wC4ll41zV_kTi9_ws5nQZ2V7Lul23LSMxDGh4KHGh2cy5hQ0x3b210V2tUWVI3eDJrS0lUWjdGQng",
      "accessor":"YL3GS6CrGE4lsgPGeyzWscsE",
      "policies":[
         "approle",
         "default"
      ],
      "token_policies":[
         "approle",
         "default"
      ],
      "metadata":null,
      "lease_duration":2764800,
      "renewable":true,
      "entity_id":"",
      "token_type":"service",
      "orphan":false,
      "mfa_requirement":null,
      "num_uses":0
   }
}
```

With no warning. I'll note that regardless of the approach, the token always seems to have `"renewable": false`, which is concerning; however, I've not yet noticed anything else amiss about the renewal process (see: the lease_duration is still set to 768 hours in this version, as opposed to continuing to count down for the unpatched version).