### PR TITLE
Revert PR #1070: DIG-2080: add crontab to rerun vault_setup every month

### DIFF
--- a/lib/vault/vault_setup.sh
+++ b/lib/vault/vault_setup.sh
@@ -168,11 +168,12 @@ if [ -f tmp/vault/service_stores.txt ]; then
     done <tmp/vault/service_stores.txt
 fi
 
-crontab -l | grep -q vault_setup
-if [[ $? -ne 0 ]]; then
-  echo "creating crontab"
-  crontab -l > temp_crontab
-  echo "0 0 1 * * cd $PWD; bash lib/vault/vault_setup.sh" >> temp_crontab
-  crontab temp_crontab
-  rm temp_crontab
-fi
+# The following was needed to reset the vault tokens before they were turned periodic
+# crontab -l | grep -q vault_setup
+# if [[ $? -ne 0 ]]; then
+#   echo "creating crontab"
+#   crontab -l > temp_crontab
+#   echo "0 0 1 * * cd $PWD; bash lib/vault/vault_setup.sh" >> temp_crontab
+#   crontab temp_crontab
+#   rm temp_crontab
+# fi


### PR DESCRIPTION
# Description
If #1077 is merged and works, we can revert #1070. I've left the code as a comment just in case we need it again.

**NB**: The crontab will still exist in everyone's systems, and will have to be removed manually.