### PR TITLE
Hotfix: remove dud test in integration tests

### DIFF
--- a/etc/tests/federation/test_federation.py
+++ b/etc/tests/federation/test_federation.py
@@ -399,3 +399,43 @@ def test_querying_site_query_unauthorized_remote_test_dataset():
             assert len(server["results"]["results"]) == 0, f"Server {server['location']['name']} improperly authorized unfederated@test.ca"
     except requests.JSONDecodeError:
         assert False, f"Invalid JSON response: {response.text}"
+
+
+# Double-check that the other server can be removed freely
+def test_remove_servers():
+    token = get_site_admin_token()
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json; charset=utf-8",
+    }
+
+    # Verify that we have more than one server
+    response = requests.get(
+        f"{ENV['CANDIG_URL']}/federation/v1/servers", headers=headers
+    )
+    assert response.ok and len(response.json()) > 1, "No other federated server found"
+    other_servers = response.json()[1:]
+
+    for server in other_servers:
+        # First delete the server
+        response = requests.delete(
+            f"{ENV['CANDIG_URL']}/federation/v1/servers/{server['id']}", headers=headers
+        )
+        print(response.text)
+        assert response.status_code == 200
+
+    # Ensure that servers are no longer visible
+    headers["federation"] = "true"
+    body = {
+        "service": "query",
+        "method": "GET",
+        "payload": {},
+        "path": "service-info",
+    }
+    response = requests.post(
+        f"{ENV['CANDIG_URL']}/federation/v1/fanout", headers=headers, json=body
+    )
+    found_it = False
+    results = response.json()
+    assert response.status_code == 200
+    assert len(results) == 1, "More than one server found after removing every server"

--- a/etc/tests/federation/test_federation.py
+++ b/etc/tests/federation/test_federation.py
@@ -414,9 +414,10 @@ def test_remove_servers():
         f"{ENV['CANDIG_URL']}/federation/v1/servers", headers=headers
     )
     assert response.ok and len(response.json()) > 1, "No other federated server found"
-    other_servers = response.json()[1:]
+    other_servers = [server for server in response.json() if server['id'] != ENV['FEDERATION_SELF_SERVER_ID']]
 
     for server in other_servers:
+        print(f"Removing {server}")
         # First delete the server
         response = requests.delete(
             f"{ENV['CANDIG_URL']}/federation/v1/servers/{server['id']}", headers=headers
@@ -427,15 +428,17 @@ def test_remove_servers():
     # Ensure that servers are no longer visible
     headers["federation"] = "true"
     body = {
-        "service": "query",
+        "service": "htsget",
         "method": "GET",
         "payload": {},
-        "path": "service-info",
+        "path": "beacon/v2/service-info",
     }
     response = requests.post(
         f"{ENV['CANDIG_URL']}/federation/v1/fanout", headers=headers, json=body
     )
-    found_it = False
-    results = response.json()
+    print(response)
     assert response.status_code == 200
+
+    results = response.json()
+    print(results)
     assert len(results) == 1, "More than one server found after removing every server"

--- a/etc/tests/integration/test_integration.py
+++ b/etc/tests/integration/test_integration.py
@@ -952,56 +952,6 @@ def test_federation_call():
     assert "results" in response.json()[0]
 
 
-# Add a server, then test to see if federated calls now include that server in the results
-def test_add_server():
-    token = get_site_admin_token()
-    headers = {
-        "Authorization": f"Bearer {token}",
-        "Content-Type": "application/json; charset=utf-8",
-    }
-
-    response = requests.get(
-        f"{ENV['CANDIG_URL']}/federation/v1/servers", headers=headers
-    )
-
-    body = {
-        "server": response.json()[0],
-        "authentication": {"issuer": ENV["KEYCLOAK_ISSUER_URL"], "token": token},
-    }
-    body["server"]["id"] = "test"
-    body["server"]["location"]["name"] = "test"
-    response = requests.post(
-        f"{ENV['CANDIG_URL']}/federation/v1/servers", headers=headers, json=body
-    )
-    assert response.status_code in [201, 204]
-
-    headers["federation"] = "true"
-    body = {
-        "service": "htsget",
-        "method": "GET",
-        "payload": {},
-        "path": "beacon/v2/service-info",
-    }
-    response = requests.post(
-        f"{ENV['CANDIG_URL']}/federation/v1/fanout", headers=headers, json=body
-    )
-    found_it = False
-    results = response.json()
-    while len(results) > 0:
-        last_result = results.pop(0)
-        print(last_result)
-        if last_result["location"]["name"] == "test":
-            found_it = True
-    assert found_it
-
-    # delete the server
-    response = requests.delete(
-        f"{ENV['CANDIG_URL']}/federation/v1/servers/test", headers=headers
-    )
-    print(response.text)
-    assert response.status_code == 200
-
-
 # Query Test: Get all donors
 def test_query_donors_all():
     token = get_token(username=ENV['CANDIG_NOT_ADMIN2_USER'],

--- a/lib/federation/initialize.py
+++ b/lib/federation/initialize.py
@@ -49,14 +49,14 @@ def main():
     if response.status_code != 200:
         print(f"POST response: {response.status_code} {response.text}")
 
-    print("Making sure our server is in federation...")
-    server = get_default_server()
-    response = requests.request("POST", url, headers=headers, json=server)
-
-    if response.status_code != 200:
-        print(f"POST response: {response.status_code} {response.text}")
     url = f"{get_env_value('FEDERATION_PUBLIC_URL')}/v1/servers"
     response = requests.request("GET", url, headers=headers)
+
+    server = get_default_server()
+    if json.dumps(server['server'], sort_keys=True) not in json.dumps(response.json(), sort_keys=True):
+        print("Adding our server to the federation")
+        response = requests.request("POST", url, headers=headers, json=server)
+        response = requests.request("GET", url, headers=headers)
     print(response.text)
 
     print("Adding services to federation...")

--- a/lib/tyk/tyk_preflight.sh
+++ b/lib/tyk/tyk_preflight.sh
@@ -58,9 +58,6 @@ mkdir -p $CONFIG_DIR $CONFIG_DIR/apps $CONFIG_DIR/policies $CONFIG_DIR/middlewar
 echo "Working on tyk.conf"  | tee -a $LOGFILE
 envsubst < ${PWD}/lib/tyk/configuration_templates/tyk.conf.tpl > ${CONFIG_DIR}/tyk.conf
 
-echo "Working on authMiddleware.js" | tee -a $LOGFILE
-envsubst < ${PWD}/lib/tyk/configuration_templates/authMiddleware.js > ${CONFIG_DIR}/middleware/authMiddleware.js
-
 echo "Working on backendAuthMiddleware.js" | tee -a $LOGFILE
 envsubst < ${PWD}/lib/tyk/configuration_templates/backendAuthMiddleware.js > ${CONFIG_DIR}/middleware/backendAuthMiddleware.js
 

--- a/lib/tyk/tyk_preflight.sh
+++ b/lib/tyk/tyk_preflight.sh
@@ -13,6 +13,10 @@ LOGFILE=$PWD/tmp/progress.txt
 
 # TODO: this image uses temp dir inside the lib/tyk which deviates from convention of this repo
 # see Makefile.authx for other details.
+
+# recreate a secret:
+make secret-tyk-secret-key; make secret-tyk-analytics-admin-key
+
 export CONFIG_DIR="$PWD/lib/tyk/tmp"
 
 KEYCLOAK_SECRET_VAL=$(cat $PWD/tmp/keycloak/client-secret)


### PR DESCRIPTION
I explained this in Slack:

> So now if we are removing a provider from tyk when we remove it from federation (as we should have always done), I see that my integration test test_add_server is faulty
It tries to add the local server again to federation, which it can do, but then delete the second one.
before, when it was NOT removing it from tyk, we’d just end up with multiple entries of the same local provider in the tyk policy. (this was something I’d noticed but never pinned down to a root cause)
but now, when it removes the provider from tyk, it has to remove all matching instances from tyk, which removes the original local server as well
Basically, this is a bad test