### PR TITLE
DIG-1982: Recompose-tyk needs to trigger a re-compose of federation

### DIFF
--- a/lib/tyk/tyk_preflight.sh
+++ b/lib/tyk/tyk_preflight.sh
@@ -15,6 +15,7 @@ LOGFILE=$PWD/tmp/progress.txt
 # see Makefile.authx for other details.
 
 # recreate a secret:
+echo "Recreating Tyk secrets"  | tee -a $LOGFILE
 make secret-tyk-secret-key; make secret-tyk-analytics-admin-key
 
 export CONFIG_DIR="$PWD/lib/tyk/tmp"

--- a/lib/tyk/tyk_setup.sh
+++ b/lib/tyk/tyk_setup.sh
@@ -76,7 +76,7 @@ generate_key() {
               "api_name": "'"${TYK_RNAGET_API_SLUG}"'",
               "Versions": ["Default"]
           }
- 
+
       }
   }'
 
@@ -87,6 +87,12 @@ generate_key() {
 }
 
 generate_key
+
+docker ps --format "{{.Names}}" | grep federation
+if [[ $? -eq 0 ]]; then
+  echo "Re-run compose-federation"  | tee -a $LOGFILE
+  make compose-federation
+fi
 
 echo "Finished Tyk key setup" | tee -a $LOGFILE
 


### PR DESCRIPTION
If you run `make recompose-tyk`, it will re-create the tyk secret key and then Federation needs to be recomposed to pick that up (just `make compose-federation`, not literally `make recompose-federation`)

While doing this, I also realized that recomposing tyk will re-create the federation and htsget policies without the federated servers, so redoing federation should add them back.

There was a bug in federation that I corrected in https://github.com/CanDIG/federation_service/pull/92 which is included in this PR.

To test, from a built system, add a federated server. Observe that there are two providers in 
```
curl "http://candig.docker.internal:5080/tyk/apis/91" \
     -H 'x-tyk-authorization: <old tyk secret>'
```

Run `make recompose-tyk`. If federation is already running, it will run `make compose-federation`. Afterwards, if you re-run the curl (make sure you've updated your tyk secret in the curl), you should see the two providers again.

If federation is not running, presumably because it hasn't been built/composed yet, tyk setup won't compose it. So there is still a weird case where if federation isn't running for whatever reason when you recomposed tyk, you'd have to manually re-run compose-federation.