### PR TITLE
add limit to kc

### DIFF
--- a/lib/keycloak/docker-compose.yml
+++ b/lib/keycloak/docker-compose.yml
@@ -1,6 +1,9 @@
 services:
   keycloak:
     image: keycloak/keycloak:${KEYCLOAK_VERSION}
+    restart: unless-stopped
+    cpus: 2
+    mem_limit: "2G"
     labels:
       - "candigv2=keycloak"
     volumes:
@@ -21,6 +24,7 @@ services:
       KEYCLOAK_PROXY_HEADERS: ${KEYCLOAK_PROXY_HEADERS}
       CANDIG_PRODUCTION_MODE: ${CANDIG_PRODUCTION_MODE}
       KEYCLOAK_HTTPS_PORT: ${KEYCLOAK_HTTPS_PORT}
+      JAVA_OPTS_KC_HEAP: "-XX:InitialRAMPercentage=50 -XX:MaxRAMPercentage=65"
     secrets:
       - keycloak-admin-password
     ports:


### PR DESCRIPTION
## What's new
- Set memory limit for Keycloak to reduce system resource usage
- Added restart policy to auto-restart Keycloak if the container stops

### How to test
- Tested on local and dev server 