### PR TITLE
tiny fix: remove spaces in var assignment

### DIFF
--- a/etc/env/example.env
+++ b/etc/env/example.env
@@ -317,11 +317,11 @@ CANDIG_DATA_PORTAL_PRIVATE_URL=http://candig-data-portal:3000
 CANDIG_DATA_PORTAL_SUPPORT_EMAIL=site_admin@test.ca
 
 # vault helper tool
-TOKEN_PATH = ${PWD}/Vault-Helper-Tool/token.txt
-PROGRESS_FILE = ${PWD}/tmp/progress.txt
+TOKEN_PATH=${PWD}/Vault-Helper-Tool/token.txt
+PROGRESS_FILE=${PWD}/tmp/progress.txt
 
 # install logging
-LOGFILE = tmp/progress.txt
+LOGFILE=tmp/progress.txt
 
 CONDA_INSTALL=bin/miniforge
 


### PR DESCRIPTION
A few variables have spaces in their assignments that might mess up `source` etc.