### PR TITLE
Include rnaget in example-production.env CANDIG_MODULES.

### DIFF
--- a/etc/env/example-production.env
+++ b/etc/env/example-production.env
@@ -2,7 +2,7 @@
 # - - -
 
 # site options
-CANDIG_MODULES=logging keycloak vault redis postgres htsget katsu query tyk opa federation candig-ingest candig-data-portal
+CANDIG_MODULES=logging keycloak vault redis postgres htsget katsu rnaget query tyk opa federation candig-ingest candig-data-portal
     #drs-server wes-server monitoring
 CANDIG_AUTH_MODULES=keycloak vault tyk opa federation
 CANDIG_DATA_MODULES=keycloak vault redis postgres logging


### PR DESCRIPTION
rnaget is required to run integration tests successfully.
rnaget is already included as a CANDIG_MODULE in both UHN and BCGSC .envs.