### PR TITLE
Optionally disable ROPC grants for user tokens

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -539,6 +539,9 @@ print-%:
 test-integration:
 	mkdir -p tmp/test
 	python ./settings.py
+ifeq ($(ENABLE_ROPC),false)
+	source ./env.sh; python pytest-tokens.py
+endif
 ifeq ($(KEEP_TEST_DATA),true)
 	source ./env.sh; pytest -v --color=yes ./etc/tests/integration -k 'not test_clean_up' $(ARGS) --report-log=./tmp/test/test-integration_$(shell date +"%Y-%m-%d_%Hh%Mm%Ss").jsonl
 else

--- a/auth_code_acceptor.py
+++ b/auth_code_acceptor.py
@@ -1,0 +1,49 @@
+import http.server
+import os
+import requests
+import socketserver
+from urllib.parse import urlparse
+
+response_handled = False
+
+class CustomHandler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        global response_handled
+        # Grab the auth code that was passed back by Keycloak
+        # Looks like a GET response with http://candig.docker.internal:5080/auth/login?session_state=c09981fd-e960-4c3e-b502-e65567763962&iss=http://candig.docker.internal:8080/auth/realms/candig&code=ecb00c59-e17d-4e75-ba88-830b377a2f8d.c09981fd-e960-4c3e-b502-e65567763962.f6eb7692-9d83-4bb0-b442-4e775ede72bc
+        query = urllib.parse(self.path)
+        query_components = dict(qc.split("=") for qc in query.split("&"))
+        code = query_components["code"]
+
+        # Use the auth code to generate a refresh/access token
+        # and also the client secret in tmp/keycloak/client-secret
+        # POST to /token
+        headers = {"Content-Type": "application/x-www-form-urlencoded"}
+        body = {
+            "client_id": os.environ['KEYCLOAK_CLIENT_ID'],
+            "client_secret": os.environ['KEYCLOAK_SECRET'],
+            "grant_type": "authorization_code",
+            "redirect_uri": os.environ['AUTH_ACCEPT_URL'],
+            "code": code
+        }
+        resp = requests.post(f"{os.environ['KEYCLOAK_PRIVATE_URL']}{os.environ['KEYCLOAK_AUTH_PREFIX']}/realms/{os.environ['KEYCLOAK_REALM']}/protocol/openid-connect/token",
+                      json=body)
+
+        # Parse the response to grab what we need, and output to tmp/site-admin-refresh-token
+
+        # Then pass back to the caller saying that we've finished
+        response_handled = True
+
+def run(server_class=http.server.HTTPServer, handler_class=CustomHandler):
+    server_address = ('0.0.0.0', int(os.environ['AUTH_ACCEPT_PORT']))
+    httpd = server_class(server_address, handler_class)
+    # We'll need to tell the user to access the Keycloak URL to login
+    print(f"To continue, please login to the server at {os.environ['KEYCLOAK_REALM_URL']}/protocol/openid-connect/auth?scope=openid+email&response_type=code&client_id=local_candig&response_mode=query&redirect_uri={os.environ['AUTH_ACCEPT_URL']}")
+    if "DEFAULT_SITE_ADMIN_USER" in os.environ:
+        with open("tmp/keycloak/test-site-admin-password", "r") as f:
+            print(f"username: {os.environ['DEFAULT_SITE_ADMIN_USER']} password: {f.read()}")
+    # http://candig.docker.internal:8080/auth/realms/candig/protocol/openid-connect/auth?scope=openid+email&response_type=code&client_id=local_candig&response_mode=query&redirect_uri=http://candig.docker.internal:5080/auth/login
+    while not response_handled:
+        httpd.handle_request()
+
+run()

--- a/auth_code_acceptor.py
+++ b/auth_code_acceptor.py
@@ -53,11 +53,11 @@ class CustomHandler(http.server.BaseHTTPRequestHandler):
             self.end_headers()
             self.wfile.write(bytes ("<html><body><h1>Login complete, please return to the command line</h1></body></html>", "utf-8"))
 
-            obtained_token = json['refresh_token']
+            obtained_token = json
         except Exception as e:
             print(e)
 
-def run(server_class=http.server.HTTPServer, handler_class=CustomHandler):
+def run(username, password, server_class=http.server.HTTPServer, handler_class=CustomHandler, refresh_token=True):
     print(ENV['CANDIG_ENV']['KEYCLOAK_CLIENT_ID'])
     server_address = (ENV['CANDIG_ENV']['CANDIG_DOMAIN'], int(ENV['CANDIG_ENV']['AUTH_ACCEPT_PORT']))
     httpd = server_class(server_address, handler_class)
@@ -67,12 +67,16 @@ def run(server_class=http.server.HTTPServer, handler_class=CustomHandler):
 
     # Tell the user what the site admin's default password is, if able
     if "DEFAULT_SITE_ADMIN_USER" in ENV['CANDIG_ENV']:
-        with open("tmp/keycloak/test-site-admin-password", "r") as f:
-            print(f"username: {ENV['CANDIG_ENV']['DEFAULT_SITE_ADMIN_USER']} password: {f.read()}")
+        print(f"username: {username} password: {password}")
     # http://candig.docker.internal:8080/auth/realms/candig/protocol/openid-connect/auth?scope=openid+email&response_type=code&client_id=local_candig&response_mode=query&redirect_uri=http://candig.docker.internal:5080/auth/login
     while not obtained_token:
         httpd.handle_request()
-    return obtained_token
+    if refresh_token:
+        return obtained_token['refresh_token']
+    else:
+        return obtained_token['access_token']
 
 if __name__ == "__main__":
-    run()
+    with open("tmp/keycloak/test-site-admin-password", "r") as f:
+        password = f.read()
+    run(ENV['CANDIG_ENV']['DEFAULT_SITE_ADMIN_USER'], password)

--- a/auth_code_acceptor.py
+++ b/auth_code_acceptor.py
@@ -2,7 +2,7 @@ import http.server
 import os
 import requests
 import socketserver
-from urllib.parse import urlparse
+from urllib.parse import urlparse, parse_qsl
 
 from settings import get_env
 
@@ -11,13 +11,24 @@ ENV = get_env()
 obtained_token = ''
 
 class CustomHandler(http.server.BaseHTTPRequestHandler):
+    # Don't log requests, as it clutters output
+    def log_message(self, format, *args):
+        pass
+
     def do_GET(self):
         global obtained_token
         try:
             # Grab the auth code that was passed back by Keycloak
             # Looks like a GET response with http://candig.docker.internal:5080/auth/login?session_state=c09981fd-e960-4c3e-b502-e65567763962&iss=http://candig.docker.internal:8080/auth/realms/candig&code=ecb00c59-e17d-4e75-ba88-830b377a2f8d.c09981fd-e960-4c3e-b502-e65567763962.f6eb7692-9d83-4bb0-b442-4e775ede72bc
             query = urlparse(self.path).query
-            query_components = dict(qc.split("=") for qc in query.split("&"))
+            query_components = dict(parse_qsl(query))
+            if 'code' not in query_components:
+                self.send_response(400)
+                self.send_header("Content-type", "text/html")
+                self.end_headers()
+                self.wfile.write(bytes("Error: 'code' not found in the Keycloak response", "utf-8"))
+                return
+
             code = query_components["code"]
 
             # Grab the Keycloak secret
@@ -52,13 +63,15 @@ class CustomHandler(http.server.BaseHTTPRequestHandler):
             self.send_header("Content-type", "text/html")
             self.end_headers()
             self.wfile.write(bytes ("<html><body><h1>Login complete, please return to the command line</h1></body></html>", "utf-8"))
+            self.close_connection = True
 
             obtained_token = json
         except Exception as e:
             print(e)
 
 def run(username, password, server_class=http.server.HTTPServer, handler_class=CustomHandler, refresh_token=True):
-    print(ENV['CANDIG_ENV']['KEYCLOAK_CLIENT_ID'])
+    global obtained_token
+    obtained_token = ''
     server_address = (ENV['CANDIG_ENV']['CANDIG_DOMAIN'], int(ENV['CANDIG_ENV']['AUTH_ACCEPT_PORT']))
     httpd = server_class(server_address, handler_class)
 

--- a/auth_code_acceptor.py
+++ b/auth_code_acceptor.py
@@ -4,46 +4,75 @@ import requests
 import socketserver
 from urllib.parse import urlparse
 
-response_handled = False
+from settings import get_env
+
+ENV = get_env()
+
+obtained_token = ''
 
 class CustomHandler(http.server.BaseHTTPRequestHandler):
     def do_GET(self):
-        global response_handled
-        # Grab the auth code that was passed back by Keycloak
-        # Looks like a GET response with http://candig.docker.internal:5080/auth/login?session_state=c09981fd-e960-4c3e-b502-e65567763962&iss=http://candig.docker.internal:8080/auth/realms/candig&code=ecb00c59-e17d-4e75-ba88-830b377a2f8d.c09981fd-e960-4c3e-b502-e65567763962.f6eb7692-9d83-4bb0-b442-4e775ede72bc
-        query = urllib.parse(self.path)
-        query_components = dict(qc.split("=") for qc in query.split("&"))
-        code = query_components["code"]
+        global obtained_token
+        try:
+            # Grab the auth code that was passed back by Keycloak
+            # Looks like a GET response with http://candig.docker.internal:5080/auth/login?session_state=c09981fd-e960-4c3e-b502-e65567763962&iss=http://candig.docker.internal:8080/auth/realms/candig&code=ecb00c59-e17d-4e75-ba88-830b377a2f8d.c09981fd-e960-4c3e-b502-e65567763962.f6eb7692-9d83-4bb0-b442-4e775ede72bc
+            query = urlparse(self.path).query
+            query_components = dict(qc.split("=") for qc in query.split("&"))
+            code = query_components["code"]
 
-        # Use the auth code to generate a refresh/access token
-        # and also the client secret in tmp/keycloak/client-secret
-        # POST to /token
-        headers = {"Content-Type": "application/x-www-form-urlencoded"}
-        body = {
-            "client_id": os.environ['KEYCLOAK_CLIENT_ID'],
-            "client_secret": os.environ['KEYCLOAK_SECRET'],
-            "grant_type": "authorization_code",
-            "redirect_uri": os.environ['AUTH_ACCEPT_URL'],
-            "code": code
-        }
-        resp = requests.post(f"{os.environ['KEYCLOAK_PRIVATE_URL']}{os.environ['KEYCLOAK_AUTH_PREFIX']}/realms/{os.environ['KEYCLOAK_REALM']}/protocol/openid-connect/token",
-                      json=body)
+            # Grab the Keycloak secret
+            with open('tmp/keycloak/client-secret', 'r') as f:
+                keycloak_secret = f.read()
 
-        # Parse the response to grab what we need, and output to tmp/site-admin-refresh-token
+            # Use the auth code to generate a refresh/access token
+            # and also the client secret in tmp/keycloak/client-secret
+            # POST to /token
+            headers = {"Content-Type": "application/x-www-form-urlencoded"}
+            body = {
+                "client_id": ENV['CANDIG_ENV']['KEYCLOAK_CLIENT_ID'],
+                "client_secret": keycloak_secret,
+                "grant_type": "authorization_code",
+                "redirect_uri": ENV['CANDIG_ENV']['AUTH_ACCEPT_URL'],
+                "code": code
+            }
+            url = f"{ENV['KEYCLOAK_REALM_URL']}/protocol/openid-connect/token"
+            # print(body)
+            resp = requests.post(url, data=body)
 
-        # Then pass back to the caller saying that we've finished
-        response_handled = True
+            # Parse the response to grab what we need, and output to
+            # tmp/site-admin-refresh-token and tmp/site-admin-access-token
+            if not resp.ok:
+                raise Exception(f"Obtaining token failed with {resp.status_code}: {resp.reason} {resp.text}")
+            json = resp.json()
+            with open('tmp/site-admin-refresh-token', 'w') as f:
+                f.write(json['refresh_token'])
+
+            # Then pass back to the caller saying that we've finished
+            self.send_response (200)
+            self.send_header("Content-type", "text/html")
+            self.end_headers()
+            self.wfile.write(bytes ("<html><body><h1>Login complete, please return to the command line</h1></body></html>", "utf-8"))
+
+            obtained_token = json['refresh_token']
+        except Exception as e:
+            print(e)
 
 def run(server_class=http.server.HTTPServer, handler_class=CustomHandler):
-    server_address = ('0.0.0.0', int(os.environ['AUTH_ACCEPT_PORT']))
+    print(ENV['CANDIG_ENV']['KEYCLOAK_CLIENT_ID'])
+    server_address = (ENV['CANDIG_ENV']['CANDIG_DOMAIN'], int(ENV['CANDIG_ENV']['AUTH_ACCEPT_PORT']))
     httpd = server_class(server_address, handler_class)
-    # We'll need to tell the user to access the Keycloak URL to login
-    print(f"To continue, please login to the server at {os.environ['KEYCLOAK_REALM_URL']}/protocol/openid-connect/auth?scope=openid+email&response_type=code&client_id=local_candig&response_mode=query&redirect_uri={os.environ['AUTH_ACCEPT_URL']}")
-    if "DEFAULT_SITE_ADMIN_USER" in os.environ:
-        with open("tmp/keycloak/test-site-admin-password", "r") as f:
-            print(f"username: {os.environ['DEFAULT_SITE_ADMIN_USER']} password: {f.read()}")
-    # http://candig.docker.internal:8080/auth/realms/candig/protocol/openid-connect/auth?scope=openid+email&response_type=code&client_id=local_candig&response_mode=query&redirect_uri=http://candig.docker.internal:5080/auth/login
-    while not response_handled:
-        httpd.handle_request()
 
-run()
+    # We'll need to tell the user to access the Keycloak URL to login
+    print(f"To continue, please login to the server at {ENV['KEYCLOAK_REALM_URL']}/protocol/openid-connect/auth?scope=openid+email&response_type=code&client_id=local_candig&response_mode=query&redirect_uri={ENV['CANDIG_ENV']['AUTH_ACCEPT_URL']}")
+
+    # Tell the user what the site admin's default password is, if able
+    if "DEFAULT_SITE_ADMIN_USER" in ENV['CANDIG_ENV']:
+        with open("tmp/keycloak/test-site-admin-password", "r") as f:
+            print(f"username: {ENV['CANDIG_ENV']['DEFAULT_SITE_ADMIN_USER']} password: {f.read()}")
+    # http://candig.docker.internal:8080/auth/realms/candig/protocol/openid-connect/auth?scope=openid+email&response_type=code&client_id=local_candig&response_mode=query&redirect_uri=http://candig.docker.internal:5080/auth/login
+    while not obtained_token:
+        httpd.handle_request()
+    return obtained_token
+
+if __name__ == "__main__":
+    run()

--- a/etc/env/example-production.env
+++ b/etc/env/example-production.env
@@ -321,6 +321,12 @@ CONDA_INSTALL=bin/miniconda3
 
 COMPOSE_IGNORE_ORPHANS=True
 
+# Alternative to the ROPC chain -- use only if you want to disable ROPC
+# NB: The AUTH_ACCEPT_URL might not work in most cases -- please configure your reverse proxy accordingly
+ENABLE_ROPC=true
+AUTH_ACCEPT_PORT=8989
+AUTH_ACCEPT_URL=http://${CANDIG_DOMAIN}:${AUTH_ACCEPT_PORT}
+
 # Default permissions for the directories in tmp/
 DIR_PERMISSIONS=775
 

--- a/etc/env/example.env
+++ b/etc/env/example.env
@@ -327,5 +327,10 @@ CONDA_INSTALL=bin/miniforge
 
 COMPOSE_IGNORE_ORPHANS=True
 
+# Alternative to the ROPC chain -- use only if you want to disable ROPC
+ENABLE_ROPC=true
+AUTH_ACCEPT_PORT=8989
+AUTH_ACCEPT_URL=http://${CANDIG_DOMAIN}:${AUTH_ACCEPT_PORT}
+
 # Default permissions for the directories in tmp/
 DIR_PERMISSIONS=775

--- a/etc/tests/integration/test_integration.py
+++ b/etc/tests/integration/test_integration.py
@@ -15,6 +15,7 @@ import authx.auth
 REPO_DIR = os.path.abspath(f"{os.path.dirname(os.path.realpath(__file__))}/../../..")
 sys.path.insert(0, os.path.abspath(f"{REPO_DIR}"))
 
+import auth_code_acceptor
 from settings import get_env
 from site_admin_token import get_site_admin_token
 
@@ -46,22 +47,26 @@ def test_keycloak():
 
 ## Can we get an access token for a user?
 def get_token(username=None, password=None, access_token=False):
-    payload = {
-        "client_id": ENV["CANDIG_CLIENT_ID"],
-        "client_secret": ENV["CANDIG_CLIENT_SECRET"],
-        "grant_type": "password",
-        "username": username,
-        "password": password,
-        "scope": "openid",
-    }
-    response = requests.post(
-        f"{ENV['KEYCLOAK_PUBLIC_URL']}/auth/realms/{ENV['KEYCLOAK_REALM']}/protocol/openid-connect/token",
-        data=payload,
-    )
-    if response.status_code == 200:
-        if access_token:
-            return response.json()["access_token"]
-        return response.json()["refresh_token"]
+    if ENV['CANDIG_ENV']['ENABLE_ROPC'].lower() == "false":
+        # ROPC disabled: need to setup the auth code service
+        return auth_code_acceptor.run(username, password, refresh_token=not access_token)
+    else:
+        payload = {
+            "client_id": ENV["CANDIG_CLIENT_ID"],
+            "client_secret": ENV["CANDIG_CLIENT_SECRET"],
+            "grant_type": "password",
+            "username": username,
+            "password": password,
+            "scope": "openid",
+        }
+        response = requests.post(
+            f"{ENV['KEYCLOAK_PUBLIC_URL']}/auth/realms/{ENV['KEYCLOAK_REALM']}/protocol/openid-connect/token",
+            data=payload,
+        )
+        if response.status_code == 200:
+            if access_token:
+                return response.json()["access_token"]
+            return response.json()["refresh_token"]
 
 
 def test_get_token():

--- a/etc/tests/integration/test_integration.py
+++ b/etc/tests/integration/test_integration.py
@@ -15,7 +15,6 @@ import authx.auth
 REPO_DIR = os.path.abspath(f"{os.path.dirname(os.path.realpath(__file__))}/../../..")
 sys.path.insert(0, os.path.abspath(f"{REPO_DIR}"))
 
-import auth_code_acceptor
 from settings import get_env
 from site_admin_token import get_site_admin_token
 
@@ -48,8 +47,23 @@ def test_keycloak():
 ## Can we get an access token for a user?
 def get_token(username=None, password=None, access_token=False):
     if ENV['CANDIG_ENV']['ENABLE_ROPC'].lower() == "false":
-        # ROPC disabled: need to setup the auth code service
-        return auth_code_acceptor.run(username, password, refresh_token=not access_token)
+        # ROPC disabled: Makefile should have queried the user
+        # and placed the tokens inside tmp/
+        with open(f"tmp/pytest-{username}-token", "r") as f:
+            refresh_token = f.read()
+        
+        if not access_token:
+            return refresh_token
+        
+        credentials = authx.auth.get_oauth_response(
+            keycloak_url=ENV["KEYCLOAK_PUBLIC_URL"],
+            client_id=ENV["CANDIG_CLIENT_ID"],
+            client_secret=ENV["CANDIG_CLIENT_SECRET"],
+            username=username,
+            password=password,
+            refresh_token=refresh_token
+            )
+        return credentials["access_token"]
     else:
         payload = {
             "client_id": ENV["CANDIG_CLIENT_ID"],
@@ -150,6 +164,7 @@ def add_program_authorization(program: str, curators: list,
     }
 
     print(f"{ENV['CANDIG_URL']}/ingest/program")
+    print(headers)
     response = requests.post(f"{ENV['CANDIG_URL']}/ingest/program", headers=headers, json=test_program)
     print(response.text)
     # if the site user is the default user, there should be a warning

--- a/etc/tests/integration/test_integration.py
+++ b/etc/tests/integration/test_integration.py
@@ -164,7 +164,6 @@ def add_program_authorization(program: str, curators: list,
     }
 
     print(f"{ENV['CANDIG_URL']}/ingest/program")
-    print(headers)
     response = requests.post(f"{ENV['CANDIG_URL']}/ingest/program", headers=headers, json=test_program)
     print(response.text)
     # if the site user is the default user, there should be a warning

--- a/lib/keycloak/client_setup.sh
+++ b/lib/keycloak/client_setup.sh
@@ -8,8 +8,8 @@ CREATE_OUTPUT=$(KCADM -full create clients -r "$KEYCLOAK_REALM" \
     -s publicClient=false \
     -s clientAuthenticatorType=client-secret \
     -s standardFlowEnabled=true \
-    -s directAccessGrantsEnabled=true \
-    -s 'redirectUris=["'"$TYK_LOGIN_TARGET_URL$KEYCLOAK_LOGIN_REDIRECT_PATH"'"]' \
+    -s directAccessGrantsEnabled=$ENABLE_ROPC \
+    -s 'redirectUris=["'"$TYK_LOGIN_TARGET_URL$KEYCLOAK_LOGIN_REDIRECT_PATH"'","'"$AUTH_ACCEPT_URL"'"]' \
     -s 'webOrigins=["'"$TYK_LOGIN_TARGET_URL"'"]' 2>&1)
 
 # Extract the client ID from the output

--- a/pytest-tokens.py
+++ b/pytest-tokens.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+
+import os
+import auth_code_acceptor
+
+print("""
+NOTE:
+In order to properly run pytest without ROPC, we will need you to sign into
+Keycloak three times with the given credentials. Please use a new incognito
+window for each
+""")
+
+admin_username = os.getenv("CANDIG_SITE_ADMIN_USER", "your site admin username")
+admin_token = auth_code_acceptor.run(
+    admin_username,
+    os.getenv("CANDIG_SITE_ADMIN_PASSWORD", "your site admin password"))
+user1_username = os.getenv("CANDIG_NOT_ADMIN_USER")
+user1_token = auth_code_acceptor.run(
+    user1_username, os.getenv("CANDIG_NOT_ADMIN_PASSWORD")
+    )
+user2_username = os.getenv("CANDIG_NOT_ADMIN2_USER")
+user2_token = auth_code_acceptor.run(
+    user2_username, os.getenv("CANDIG_NOT_ADMIN2_PASSWORD")
+    )
+
+# NB: Grabbing a new admin token will invalidate the existing one, so we need to
+# write over the site-admin-refresh-token file as well
+with open(f"tmp/site-admin-refresh-token", "w") as f:
+    f.write(admin_token)
+with open(f"tmp/pytest-{admin_username}-token", "w") as f:
+    f.write(admin_token)
+with open(f"tmp/pytest-{user1_username}-token", "w") as f:
+    f.write(user1_token)
+with open(f"tmp/pytest-{user2_username}-token", "w") as f:
+    f.write(user2_token)

--- a/settings.py
+++ b/settings.py
@@ -72,6 +72,8 @@ def get_env():
     vars["DB_PATH"] = "postgres-db"
     vars["FEDERATION_SELF_SERVER_ID"] = get_env_value("FEDERATION_SELF_SERVER_ID")
     vars["CANDIG_SITE_LOCATION"] = get_env_value("CANDIG_SITE_LOCATION")
+    vars["DISABLE_ROPC"] = get_env_value("DISABLE_ROPC")
+    vars["AUTH_ACCEPT_URL"] = get_env_value("AUTH_ACCEPT_URL")
 
     # test users (note that they must be all lowercase or keycloak setup fails):
     if get_env_value("DEFAULT_SITE_ADMIN_USER") is not None:

--- a/site_admin_token.py
+++ b/site_admin_token.py
@@ -25,9 +25,7 @@ def get_site_admin_token(username=None, password=None, refresh_token=None):
             # if we're not allowed to do ROPC, we need to ask the user to login
             # through keycloak
             if ENV['CANDIG_ENV']['ENABLE_ROPC'].lower() == "false":
-                auth_code_acceptor.run()
-                with open("tmp/site-admin-refresh-token") as f:
-                    refresh_token = f.read().splitlines().pop()
+                refresh_token = auth_code_acceptor.run(username, password)
     try:
         credentials = authx.auth.get_oauth_response(
             keycloak_url=ENV["KEYCLOAK_PUBLIC_URL"],

--- a/site_admin_token.py
+++ b/site_admin_token.py
@@ -3,6 +3,7 @@ import os
 import sys
 import getpass
 from settings import get_env
+import auth_code_acceptor
 
 ENV = get_env()
 
@@ -21,7 +22,12 @@ def get_site_admin_token(username=None, password=None, refresh_token=None):
             if password is None or password == "":
                 username = input("Enter username: ")
                 password = getpass.getpass("Enter password: ")
-
+            # if we're not allowed to do ROPC, we need to ask the user to login
+            # through keycloak
+            if ENV['CANDIG_ENV']['ENABLE_ROPC'].lower() == "false":
+                auth_code_acceptor.run()
+                with open("tmp/site-admin-refresh-token") as f:
+                    refresh_token = f.read().splitlines().pop()
     try:
         credentials = authx.auth.get_oauth_response(
             keycloak_url=ENV["KEYCLOAK_PUBLIC_URL"],


### PR DESCRIPTION
# Description
[Jira ticket about ROPC removal](https://tfri.atlassian.net/browse/DHDPS-340)

Per [guidelines on OIDC](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-security-topics#section-2.4), the usage of the Resource Owner Password Credentials (ROPC) grant is **heavily discouraged**. We've been using it for convenience and will likely still support it because it makes DevOps much easier, but with the DHDP Keycloak server not allowing ROPC we need to have an option to disable it.

The ROPC grant is what we've been using to grab access/refresh tokens in every instance except when the user logs into the portal -- ROPC allows us to sign in as users without needing to use a frontend at all. This PR allows you to remove this ability by specifying the following environment variables:
```
# Alternative to the ROPC chain -- use only if you want to disable ROPC
ENABLE_ROPC=true
AUTH_ACCEPT_PORT=8989
AUTH_ACCEPT_URL=http://${CANDIG_DOMAIN}:${AUTH_ACCEPT_PORT}
```

# To test
Please set `ENABLE_ROPC=false` in your `.env` and rebuild everything & test. **Please note that you will be prompted at several points to sign in to the given URL with the given credentials**. This may not work if you have another program listening at port 8989.

# Other notes
We don't yet have a way of doing auth_code grants *without* any browser intervention at all, which we might need for automated deployment.