### PR TITLE
Change to allow client auth setup instead of user auth.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -539,7 +539,7 @@ print-%:
 test-integration:
 	mkdir -p tmp/test
 	python ./settings.py
-ifeq ($(ENABLE_ROPC),false)
+ifeq ($(ENABLE_ROPC),'AUTH_CODE')
 	source ./env.sh; python pytest-tokens.py
 endif
 ifeq ($(KEEP_TEST_DATA),true)

--- a/etc/env/example-production.env
+++ b/etc/env/example-production.env
@@ -19,8 +19,7 @@ CANDIG_PRODUCTION_MODE=1
 CANDIG_VERSION=v6.0.0
 
 # this is the unique key used by your site IDP to identify users.
-CANDIG_USER_KEY=email
-# Note: change to preferred_username for client auth grant
+CANDIG_USER_KEY=preferred_username
 
 # default name for built-in site admin
 DEFAULT_SITE_ADMIN_USER=site_admin@test.ca

--- a/etc/env/example-production.env
+++ b/etc/env/example-production.env
@@ -20,9 +20,11 @@ CANDIG_VERSION=v6.0.0
 
 # this is the unique key used by your site IDP to identify users.
 CANDIG_USER_KEY=email
+# Note: change to preferred_username for client auth grant
 
 # default name for built-in site admin
 DEFAULT_SITE_ADMIN_USER=site_admin@test.ca
+# Note: change to the preferred_username of your client for client auth grant
 
 # default name for admin accounts
 DEFAULT_ADMIN_USER=admin
@@ -321,11 +323,15 @@ CONDA_INSTALL=bin/miniconda3
 
 COMPOSE_IGNORE_ORPHANS=True
 
-# Alternative to the ROPC chain -- use only if you want to disable ROPC
+# Alternative to the ROPC chain -- alter only if ROPC needs to be disabled (due to e.g. security concerns)
+# Options are ROPC CLIENT AUTH_CODE
+OIDC_CHAIN=ROPC
+# AUTH_CODE-specific variables (for use in auth_code_acceptor.py):
 # NB: The AUTH_ACCEPT_URL might not work in most cases -- please configure your reverse proxy accordingly
-ENABLE_ROPC=true
 AUTH_ACCEPT_PORT=8989
 AUTH_ACCEPT_URL=http://${CANDIG_DOMAIN}:${AUTH_ACCEPT_PORT}
+# CLIENT-specific variables
+KEYCLOAK_SERVICE_CLIENT_ID=site_admin
 
 # Default permissions for the directories in tmp/
 DIR_PERMISSIONS=775

--- a/etc/env/example.env
+++ b/etc/env/example.env
@@ -19,8 +19,7 @@ CANDIG_PRODUCTION_MODE=0
 CANDIG_VERSION=v6.0.0
 
 # this is the unique key used by your site IDP to identify users.
-CANDIG_USER_KEY=email
-# Note: change to preferred_username for client auth grant
+CANDIG_USER_KEY=preferred_username
 
 # default name for built-in site admin
 DEFAULT_SITE_ADMIN_USER=site_admin@${CANDIG_SITE_LOCATION}-test.ca

--- a/etc/env/example.env
+++ b/etc/env/example.env
@@ -20,9 +20,11 @@ CANDIG_VERSION=v6.0.0
 
 # this is the unique key used by your site IDP to identify users.
 CANDIG_USER_KEY=email
+# Note: change to preferred_username for client auth grant
 
 # default name for built-in site admin
 DEFAULT_SITE_ADMIN_USER=site_admin@${CANDIG_SITE_LOCATION}-test.ca
+# Note: change to the preferred_username of your client for client auth grant
 
 # default name for admin accounts
 DEFAULT_ADMIN_USER=admin
@@ -329,10 +331,14 @@ CONDA_INSTALL=bin/miniforge
 
 COMPOSE_IGNORE_ORPHANS=True
 
-# Alternative to the ROPC chain -- use only if you want to disable ROPC
-ENABLE_ROPC=true
+# Alternative to the ROPC chain -- alter only if ROPC needs to be disabled (due to e.g. security concerns)
+# Options are ROPC CLIENT AUTH_CODE
+OIDC_CHAIN=ROPC
+# AUTH_CODE-specific variables (for use in auth_code_acceptor.py):
 AUTH_ACCEPT_PORT=8989
 AUTH_ACCEPT_URL=http://${CANDIG_DOMAIN}:${AUTH_ACCEPT_PORT}
+# CLIENT-specific variables
+KEYCLOAK_SERVICE_CLIENT_ID=site_admin
 
 # Default permissions for the directories in tmp/
 DIR_PERMISSIONS=775

--- a/etc/tests/integration/test_integration.py
+++ b/etc/tests/integration/test_integration.py
@@ -46,7 +46,7 @@ def test_keycloak():
 
 ## Can we get an access token for a user?
 def get_token(username=None, password=None, access_token=False):
-    if ENV['CANDIG_ENV']['ENABLE_ROPC'].lower() == "false":
+    if ENV['CANDIG_ENV']['ENABLE_ROPC'].lower() == "auth_code":
         # ROPC disabled: Makefile should have queried the user
         # and placed the tokens inside tmp/
         with open(f"tmp/pytest-{username}-token", "r") as f:
@@ -62,6 +62,14 @@ def get_token(username=None, password=None, access_token=False):
             username=username,
             password=password,
             refresh_token=refresh_token
+            )
+        return credentials["access_token"]
+    elif ENV['CANDIG_ENV']['ENABLE_ROPC'].lower() == "client":
+        credentials = authx.auth.get_oauth_response(
+            keycloak_url=ENV["KEYCLOAK_PUBLIC_URL"],
+            client_id=username,
+            client_secret=password,
+            client_account=True
             )
         return credentials["access_token"]
     else:

--- a/etc/tests/integration/test_integration.py
+++ b/etc/tests/integration/test_integration.py
@@ -46,7 +46,7 @@ def test_keycloak():
 
 ## Can we get an access token for a user?
 def get_token(username=None, password=None, access_token=False):
-    if ENV['CANDIG_ENV']['ENABLE_ROPC'].lower() == "auth_code":
+    if ENV['CANDIG_ENV']['OIDC_CHAIN'].lower() == "auth_code":
         # ROPC disabled: Makefile should have queried the user
         # and placed the tokens inside tmp/
         with open(f"tmp/pytest-{username}-token", "r") as f:
@@ -64,11 +64,11 @@ def get_token(username=None, password=None, access_token=False):
             refresh_token=refresh_token
             )
         return credentials["access_token"]
-    elif ENV['CANDIG_ENV']['ENABLE_ROPC'].lower() == "client":
+    elif ENV['CANDIG_ENV']['OIDC_CHAIN'].lower() == "client" and username == ENV["CANDIG_SITE_ADMIN_USER"]:
         credentials = authx.auth.get_oauth_response(
             keycloak_url=ENV["KEYCLOAK_PUBLIC_URL"],
-            client_id=username,
-            client_secret=password,
+            client_id=ENV["KEYCLOAK_SERVICE_CLIENT_ID"],
+            client_secret=ENV["CANDIG_SERVICE_CLIENT_SECRET"],
             client_account=True
             )
         return credentials["access_token"]

--- a/etc/venv/requirements.txt
+++ b/etc/venv/requirements.txt
@@ -7,7 +7,7 @@ pytest>=8.3.3
 pytz>=2024.2
 minio>=7.2.12
 GitPython>=3.1.43
-candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@feature/client-auth
+candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.8.4
 candigv2-logging@git+https://github.com/CanDIG/candigv2-logging.git@v1.0.1
 clinical_etl@git+https://github.com/CanDIG/clinical_ETL_code.git@v3.1.2
 werkzeug>=2.3.8 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/etc/venv/requirements.txt
+++ b/etc/venv/requirements.txt
@@ -7,7 +7,7 @@ pytest>=8.3.3
 pytz>=2024.2
 minio>=7.2.12
 GitPython>=3.1.43
-candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.8.3
+candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@feature/client-auth
 candigv2-logging@git+https://github.com/CanDIG/candigv2-logging.git@v1.0.1
 clinical_etl@git+https://github.com/CanDIG/clinical_ETL_code.git@v3.1.2
 werkzeug>=2.3.8 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/lib/keycloak/client_setup.sh
+++ b/lib/keycloak/client_setup.sh
@@ -1,6 +1,22 @@
 # This script creates and configures a client within a Keycloak realm
 echo -e "${BLUE}Creating client: $KEYCLOAK_CLIENT_ID${DEFAULT}"
 
+ENABLE_ROPC="false"
+if [ "${OIDC_CHAIN,,}" = "client" ] || [ "${OIDC_CHAIN,,}" = "ropc" ]; then
+    ENABLE_ROPC="true"
+fi
+
+add_audience_scope() {
+    local CLIENT_UUID="${1}"
+    local AUDIENCE="${2}"
+    local SCOPE_NAME="${CLIENT}-${AUDIENCE}-audience"
+    KCADM create clients/$CLIENT_UUID/protocol-mappers/models -r $KEYCLOAK_REALM \
+        -s name=$SCOPE_NAME \
+        -s protocol=openid-connect \
+        -s protocolMapper=oidc-audience-mapper \
+        -s config="{\"included.client.audience\" : \"$AUDIENCE\",\"id.token.claim\" : \"true\",\"access.token.claim\" : \"true\"}"
+}
+
 CREATE_OUTPUT=$(KCADM -full create clients -r "$KEYCLOAK_REALM" \
     -s clientId="$KEYCLOAK_CLIENT_ID" \
     -s enabled=true \
@@ -13,17 +29,31 @@ CREATE_OUTPUT=$(KCADM -full create clients -r "$KEYCLOAK_REALM" \
     -s 'webOrigins=["'"$TYK_LOGIN_TARGET_URL"'"]' 2>&1)
 
 # Extract the client ID from the output
-CLIENT_ID=$(echo $CREATE_OUTPUT | grep -oE '[0-9a-fA-F-]{36}')
+CLIENT_UUID=$(echo $CREATE_OUTPUT | grep -oE '[0-9a-fA-F-]{36}')
 
 # Create client scopes
-SCOPE_NAME="${KEYCLOAK_CLIENT_ID}-audience"
-KCADM create clients/$CLIENT_ID/protocol-mappers/models -r $KEYCLOAK_REALM \
-    -s name=$SCOPE_NAME \
-    -s protocol=openid-connect \
-    -s protocolMapper=oidc-audience-mapper \
-    -s config="{\"included.client.audience\" : \"$KEYCLOAK_CLIENT_ID\",\"id.token.claim\" : \"true\",\"access.token.claim\" : \"true\"}"
-
+add_audience_scope "${CLIENT_UUID}" "${KEYCLOAK_CLIENT_ID}"
 
 # EXPORT client secret
-CLIENT_SECRET=$(KCADM -full get clients/"$CLIENT_ID"/client-secret -r "$KEYCLOAK_REALM" | sed -n '/{/,/}/p' | jq -r '.value')
+CLIENT_SECRET=$(KCADM -full get clients/"$CLIENT_UUID"/client-secret -r "$KEYCLOAK_REALM" | sed -n '/{/,/}/p' | jq -r '.value')
 echo -n "$CLIENT_SECRET" > tmp/keycloak/client-secret
+
+# If we're using client authorization, we'll also need a client for the admin
+if [ "${OIDC_CHAIN,,}" = "client" ]; then
+    # Note: The terminology here is confusing, because we use the word "ID" for a couple different things
+    CREATE_OUTPUT=$(KCADM -full create clients -r "$KEYCLOAK_REALM" \
+        -s clientId="$KEYCLOAK_SERVICE_CLIENT_ID" \
+        -s enabled=true \
+        -s protocol=openid-connect \
+        -s publicClient=false \
+        -s clientAuthenticatorType=client-secret \
+        -s standardFlowEnabled=false \
+        -s directAccessGrantsEnabled=false  2>&1)
+    SERVICE_CLIENT_UUID=$(echo $CREATE_OUTPUT | grep -oE '[0-9a-fA-F-]{36}')
+
+    # Service accounts need two audiences: one for themselves, and one for our usual CanDIG client
+    # (without it they won't authenticate properly with Tyk)
+    add_audience_scope "${SERVICE_CLIENT_UUID}" "${KEYCLOAK_CLIENT_ID}"
+    add_audience_scope "${SERVICE_CLIENT_UUID}" "${KEYCLOAK_SERVICE_CLIENT_ID}"
+fi
+

--- a/lib/keycloak/client_setup.sh
+++ b/lib/keycloak/client_setup.sh
@@ -48,6 +48,7 @@ if [ "${OIDC_CHAIN,,}" = "client" ]; then
         -s publicClient=false \
         -s clientAuthenticatorType=client-secret \
         -s standardFlowEnabled=false \
+        -s serviceAccountsEnabled=true \
         -s directAccessGrantsEnabled=false  2>&1)
     SERVICE_CLIENT_UUID=$(echo $CREATE_OUTPUT | grep -oE '[0-9a-fA-F-]{36}')
 
@@ -55,5 +56,8 @@ if [ "${OIDC_CHAIN,,}" = "client" ]; then
     # (without it they won't authenticate properly with Tyk)
     add_audience_scope "${SERVICE_CLIENT_UUID}" "${KEYCLOAK_CLIENT_ID}"
     add_audience_scope "${SERVICE_CLIENT_UUID}" "${KEYCLOAK_SERVICE_CLIENT_ID}"
+
+    SERVICE_CLIENT_SECRET=$(KCADM -full get clients/"$SERVICE_CLIENT_UUID"/client-secret -r "$KEYCLOAK_REALM" | sed -n '/{/,/}/p' | jq -r '.value')
+    echo -n "$SERVICE_CLIENT_SECRET" > tmp/keycloak/service-client-secret
 fi
 

--- a/lib/keycloak/client_setup.sh
+++ b/lib/keycloak/client_setup.sh
@@ -2,7 +2,9 @@
 echo -e "${BLUE}Creating client: $KEYCLOAK_CLIENT_ID${DEFAULT}"
 
 ENABLE_ROPC="false"
-if [ "${OIDC_CHAIN,,}" = "client" ] || [ "${OIDC_CHAIN,,}" = "ropc" ]; then
+# Support older versions of bash
+OIDC_CHAIN_LOWERCASE=$(echo ${OIDC_CHAIN} | tr '[:upper:]' '[:lower:]')
+if [ "${OIDC_CHAIN_LOWERCASE}" = "client" ] || [ "${OIDC_CHAIN_LOWERCASE}" = "ropc" ]; then
     ENABLE_ROPC="true"
 fi
 
@@ -39,7 +41,7 @@ CLIENT_SECRET=$(KCADM -full get clients/"$CLIENT_UUID"/client-secret -r "$KEYCLO
 echo -n "$CLIENT_SECRET" > tmp/keycloak/client-secret
 
 # If we're using client authorization, we'll also need a client for the admin
-if [ "${OIDC_CHAIN,,}" = "client" ]; then
+if [ "${OIDC_CHAIN_LOWERCASE}" = "client" ]; then
     # Note: The terminology here is confusing, because we use the word "ID" for a couple different things
     CREATE_OUTPUT=$(KCADM -full create clients -r "$KEYCLOAK_REALM" \
         -s clientId="$KEYCLOAK_SERVICE_CLIENT_ID" \

--- a/lib/keycloak/user_setup.sh
+++ b/lib/keycloak/user_setup.sh
@@ -21,4 +21,6 @@ create_user_and_set_password() {
 # params: username password email firstname lastname
 create_user_and_set_password "$CANDIG_NOT_ADMIN_USER" "$(cat tmp/keycloak/test-user-password)" "$CANDIG_NOT_ADMIN_USER" "One" "User"
 create_user_and_set_password "$CANDIG_NOT_ADMIN2_USER" "$(cat tmp/keycloak/test-user2-password)" "$CANDIG_NOT_ADMIN2_USER" "Two" "User"
-create_user_and_set_password "$DEFAULT_SITE_ADMIN_USER" "$(cat tmp/keycloak/test-site-admin-password)" "$DEFAULT_SITE_ADMIN_USER" "Site" "Admin"
+if [ "${OIDC_CHAIN,,}" != "client" ]; then
+    create_user_and_set_password "$DEFAULT_SITE_ADMIN_USER" "$(cat tmp/keycloak/test-site-admin-password)" "$DEFAULT_SITE_ADMIN_USER" "Site" "Admin"
+fi

--- a/lib/keycloak/user_setup.sh
+++ b/lib/keycloak/user_setup.sh
@@ -21,6 +21,8 @@ create_user_and_set_password() {
 # params: username password email firstname lastname
 create_user_and_set_password "$CANDIG_NOT_ADMIN_USER" "$(cat tmp/keycloak/test-user-password)" "$CANDIG_NOT_ADMIN_USER" "One" "User"
 create_user_and_set_password "$CANDIG_NOT_ADMIN2_USER" "$(cat tmp/keycloak/test-user2-password)" "$CANDIG_NOT_ADMIN2_USER" "Two" "User"
-if [ "${OIDC_CHAIN,,}" != "client" ]; then
+# Support older versions of bash
+OIDC_CHAIN_LOWERCASE=$(echo ${OIDC_CHAIN} | tr '[:upper:]' '[:lower:]')
+if [ "${OIDC_CHAIN_LOWERCASE}" != "client" ]; then
     create_user_and_set_password "$DEFAULT_SITE_ADMIN_USER" "$(cat tmp/keycloak/test-site-admin-password)" "$DEFAULT_SITE_ADMIN_USER" "Site" "Admin"
 fi

--- a/lib/tyk/configuration_templates/api_federation.json.tpl
+++ b/lib/tyk/configuration_templates/api_federation.json.tpl
@@ -88,15 +88,8 @@
         "VAULT_ROLE":"researcher"
     },
     "openid_options": {
-    "segregate_by_client": false,
-    "providers": [
-            {
-                "issuer": "${KEYCLOAK_ISSUER_URL}",
-                "client_ids": {
-                    "${KEYCLOAK_CLIENT_ID_64}": "${TYK_POLICY_ID}"
-                }
-            }
-        ]
+        "segregate_by_client": false,
+        "providers": ${PROVIDERS}
     },
 
 

--- a/lib/tyk/configuration_templates/api_htsget.json.tpl
+++ b/lib/tyk/configuration_templates/api_htsget.json.tpl
@@ -88,15 +88,8 @@
         "VAULT_ROLE":"researcher"
     },
     "openid_options": {
-    "segregate_by_client": false,
-    "providers": [
-            {
-                "issuer": "${KEYCLOAK_ISSUER_URL}",
-                "client_ids": {
-                    "${KEYCLOAK_CLIENT_ID_64}": "${TYK_POLICY_ID}"
-                }
-            }
-        ]
+        "segregate_by_client": false,
+        "providers": ${PROVIDERS}
     },
 
 

--- a/lib/tyk/configuration_templates/api_ingest.json.tpl
+++ b/lib/tyk/configuration_templates/api_ingest.json.tpl
@@ -88,15 +88,8 @@
         "VAULT_ROLE":"researcher"
     },
     "openid_options": {
-    "segregate_by_client": false,
-    "providers": [
-            {
-                "issuer": "${KEYCLOAK_ISSUER_URL}",
-                "client_ids": {
-                    "${KEYCLOAK_CLIENT_ID_64}": "${TYK_POLICY_ID}"
-                }
-            }
-        ]
+        "segregate_by_client": false,
+        "providers": ${PROVIDERS}
     },
 
 

--- a/lib/tyk/configuration_templates/api_katsu.json.tpl
+++ b/lib/tyk/configuration_templates/api_katsu.json.tpl
@@ -88,15 +88,8 @@
         "VAULT_ROLE":"researcher"
     },
     "openid_options": {
-    "segregate_by_client": false,
-    "providers": [
-            {
-                "issuer": "${KEYCLOAK_ISSUER_URL}",
-                "client_ids": {
-                    "${KEYCLOAK_CLIENT_ID_64}": "${TYK_POLICY_ID}"
-                }
-            }
-        ]
+        "segregate_by_client": false,
+        "providers": ${PROVIDERS}
     },
 
 

--- a/lib/tyk/configuration_templates/api_mcode_candig_data_portal.json.tpl
+++ b/lib/tyk/configuration_templates/api_mcode_candig_data_portal.json.tpl
@@ -91,15 +91,8 @@
         "VAULT_ROLE":"researcher"
     },
     "openid_options": {
-    "segregate_by_client": false,
-    "providers": [
-            {
-                "issuer": "${KEYCLOAK_ISSUER_URL}",
-                "client_ids": {
-                    "${KEYCLOAK_CLIENT_ID_64}": "${TYK_POLICY_ID}"
-                }
-            }
-        ]
+        "segregate_by_client": false,
+        "providers": ${PROVIDERS}
     },
 
 

--- a/lib/tyk/configuration_templates/api_opa.json.tpl
+++ b/lib/tyk/configuration_templates/api_opa.json.tpl
@@ -89,15 +89,8 @@
         "VAULT_ROLE":"researcher"
     },
     "openid_options": {
-    "segregate_by_client": false,
-    "providers": [
-            {
-                "issuer": "${KEYCLOAK_ISSUER_URL}",
-                "client_ids": {
-                    "${KEYCLOAK_CLIENT_ID_64}": "${TYK_POLICY_ID}"
-                }
-            }
-        ]
+        "segregate_by_client": false,
+        "providers": ${PROVIDERS}
     },
 
 

--- a/lib/tyk/configuration_templates/api_query.json.tpl
+++ b/lib/tyk/configuration_templates/api_query.json.tpl
@@ -88,15 +88,8 @@
         "VAULT_ROLE":"researcher"
     },
     "openid_options": {
-    "segregate_by_client": false,
-    "providers": [
-            {
-                "issuer": "${KEYCLOAK_ISSUER_URL}",
-                "client_ids": {
-                    "${KEYCLOAK_CLIENT_ID_64}": "${TYK_POLICY_ID}"
-                }
-            }
-        ]
+        "segregate_by_client": false,
+        "providers": ${PROVIDERS}
     },
 
 

--- a/lib/tyk/configuration_templates/api_rnaget.json.tpl
+++ b/lib/tyk/configuration_templates/api_rnaget.json.tpl
@@ -88,15 +88,8 @@
         "VAULT_ROLE":"researcher"
     },
     "openid_options": {
-    "segregate_by_client": false,
-    "providers": [
-            {
-                "issuer": "${KEYCLOAK_ISSUER_URL}",
-                "client_ids": {
-                    "${KEYCLOAK_CLIENT_ID_64}": "${TYK_POLICY_ID}"
-                }
-            }
-        ]
+        "segregate_by_client": false,
+        "providers": ${PROVIDERS}
     },
 
 

--- a/lib/tyk/configuration_templates/api_template.json.tpl
+++ b/lib/tyk/configuration_templates/api_template.json.tpl
@@ -89,15 +89,8 @@
         "VAULT_ROLE":"researcher"
     },
     "openid_options": {
-    "segregate_by_client": false,
-    "providers": [
-            {
-                "issuer": "${KEYCLOAK_ISSUER_URL}",
-                "client_ids": {
-                    "${KEYCLOAK_CLIENT_ID_64}": "${TYK_POLICY_ID}"
-                }
-            }
-        ]
+        "segregate_by_client": false,
+        "providers": ${PROVIDERS}
     },
 
 

--- a/lib/tyk/configuration_templates/api_vault.json.tpl
+++ b/lib/tyk/configuration_templates/api_vault.json.tpl
@@ -82,15 +82,8 @@
         "VAULT_ROLE":"researcher"
     },
     "openid_options": {
-    "segregate_by_client": false,
-    "providers": [
-            {
-                "issuer": "${KEYCLOAK_ISSUER_URL}",
-                "client_ids": {
-                    "${KEYCLOAK_CLIENT_ID_64}": "${TYK_POLICY_ID}"
-                }
-            }
-        ]
+        "segregate_by_client": false,
+        "providers": ${PROVIDERS}
     },
 
 

--- a/lib/tyk/tyk_preflight.sh
+++ b/lib/tyk/tyk_preflight.sh
@@ -58,6 +58,29 @@ export REDIS_SECRET_KEY=$REDIS_SECRET_KEY_VAL
 
 mkdir -p $CONFIG_DIR $CONFIG_DIR/apps $CONFIG_DIR/policies $CONFIG_DIR/middleware
 
+export PROVIDERS="[
+            {
+                \"issuer\": "${KEYCLOAK_ISSUER_URL}",
+                \"client_ids\": {
+                    \"${KEYCLOAK_CLIENT_ID_64}\": \"${TYK_POLICY_ID}\"
+                }
+            }
+        ]"
+
+# Under client auth, we've got to also add the site admin client as well
+if [[ ${OIDC_CHAIN,,} = "client" ]]; then
+    export KEYCLOAK_SERVICE_CLIENT_ID_64=$(echo -n ${KEYCLOAK_SERVICE_CLIENT_ID} | base64)
+    export PROVIDERS="[
+            {
+                \"issuer\": \"${KEYCLOAK_ISSUER_URL}\",
+                \"client_ids\": {
+                    \"${KEYCLOAK_CLIENT_ID_64}\": \"${TYK_POLICY_ID}\",
+                    \"${KEYCLOAK_SERVICE_CLIENT_ID_64}\": \"${TYK_POLICY_ID}\"
+                }
+            }
+        ]"
+fi
+
 # Copy files from template configs
 
 echo "Working on tyk.conf"  | tee -a $LOGFILE

--- a/lib/tyk/tyk_preflight.sh
+++ b/lib/tyk/tyk_preflight.sh
@@ -67,8 +67,11 @@ export PROVIDERS="[
             }
         ]"
 
+# Support older versions of bash
+OIDC_CHAIN_LOWERCASE=$(echo ${OIDC_CHAIN} | tr '[:upper:]' '[:lower:]')
+
 # Under client auth, we've got to also add the site admin client as well
-if [[ ${OIDC_CHAIN,,} = "client" ]]; then
+if [[ ${OIDC_CHAIN_LOWERCASE} = "client" ]]; then
     export KEYCLOAK_SERVICE_CLIENT_ID_64=$(echo -n ${KEYCLOAK_SERVICE_CLIENT_ID} | base64)
     export PROVIDERS="[
             {

--- a/settings.py
+++ b/settings.py
@@ -73,7 +73,8 @@ def get_env():
     vars["DB_PATH"] = "postgres-db"
     vars["FEDERATION_SELF_SERVER_ID"] = get_env_value("FEDERATION_SELF_SERVER_ID")
     vars["CANDIG_SITE_LOCATION"] = get_env_value("CANDIG_SITE_LOCATION")
-    vars["DISABLE_ROPC"] = get_env_value("DISABLE_ROPC")
+    vars["OIDC_CHAIN"] = get_env_value("OIDC_CHAIN").lower()
+    vars["KEYCLOAK_SERVICE_CLIENT_ID"] = get_env_value("KEYCLOAK_SERVICE_CLIENT_ID").lower()
     vars["AUTH_ACCEPT_URL"] = get_env_value("AUTH_ACCEPT_URL")
 
     # test users (note that they must be all lowercase or keycloak setup fails):

--- a/settings.py
+++ b/settings.py
@@ -62,6 +62,9 @@ def get_env():
     if os.path.isfile("tmp/keycloak/client-secret"):
         with open("tmp/keycloak/client-secret") as f:
             vars["CANDIG_CLIENT_SECRET"] = f.read().splitlines().pop()
+    if os.path.isfile("tmp/keycloak/service-client-secret"):
+        with open("tmp/keycloak/service-client-secret") as f:
+            vars["CANDIG_SERVICE_CLIENT_SECRET"] = f.read().splitlines().pop()
     if os.path.isfile("tmp/vault/keys.txt"):
         with open("tmp/vault/keys.txt") as f:
             vars["VAULT_ROOT_TOKEN"] = f.read().splitlines().pop(-1)

--- a/site_admin_token.py
+++ b/site_admin_token.py
@@ -24,16 +24,18 @@ def get_site_admin_token(username=None, password=None, refresh_token=None):
                 password = getpass.getpass("Enter password: ")
             # if we're not allowed to do ROPC, we need to ask the user to login
             # through keycloak
-            if ENV['CANDIG_ENV']['ENABLE_ROPC'].lower() == "false":
+            if ENV['CANDIG_ENV']['OIDC_CHAIN'].lower() == "auth_code":
                 refresh_token = auth_code_acceptor.run(username, password)
     try:
+        is_client_auth = ENV['CANDIG_ENV']['OIDC_CHAIN'].lower() == "client"
         credentials = authx.auth.get_oauth_response(
             keycloak_url=ENV["KEYCLOAK_PUBLIC_URL"],
-            client_id=ENV["CANDIG_CLIENT_ID"],
+            client_id=ENV["CANDIG_CLIENT_ID"] if not is_client_auth else ENV["KEYCLOAK_SERVICE_CLIENT_ID"],
             client_secret=ENV["CANDIG_CLIENT_SECRET"],
             username=username,
             password=password,
-            refresh_token=refresh_token
+            refresh_token=refresh_token,
+            client_account=is_client_auth
             )
 
         if "error" in credentials:
@@ -47,8 +49,10 @@ def get_site_admin_token(username=None, password=None, refresh_token=None):
                 print(type(e))
             return get_site_admin_token()
 
-        with open(f"tmp/site-admin-refresh-token", "w") as f:
-            f.write(credentials["refresh_token"])
+        # If we get a refresh token (not valid for client_auth), store it for later
+        if not is_client_auth:
+            with open(f"tmp/site-admin-refresh-token", "w") as f:
+                f.write(credentials["refresh_token"])
 
         return credentials["access_token"]
     except Exception as e:

--- a/site_admin_token.py
+++ b/site_admin_token.py
@@ -31,7 +31,7 @@ def get_site_admin_token(username=None, password=None, refresh_token=None):
         credentials = authx.auth.get_oauth_response(
             keycloak_url=ENV["KEYCLOAK_PUBLIC_URL"],
             client_id=ENV["CANDIG_CLIENT_ID"] if not is_client_auth else ENV["KEYCLOAK_SERVICE_CLIENT_ID"],
-            client_secret=ENV["CANDIG_CLIENT_SECRET"],
+            client_secret=ENV["CANDIG_CLIENT_SECRET"] if not is_client_auth else ENV["CANDIG_SERVICE_CLIENT_SECRET"],
             username=username,
             password=password,
             refresh_token=refresh_token,


### PR DESCRIPTION
# To test
Swap the following in .env:
```
(candig) 14:30 fnguyen@fnguyen-worktop:~/Documents/CanDIGv2$ diff etc/env/example.env .env
5c5
< CANDIG_MODULES=logging keycloak vault redis postgres htsget katsu rnaget query tyk opa federation candig-ingest candig-data-portal
---
> CANDIG_MODULES=logging vault redis postgres htsget katsu rnaget query tyk opa federation candig-ingest candig-data-portal
7,8c7,8
< CANDIG_AUTH_MODULES=keycloak vault tyk opa federation
< CANDIG_DATA_MODULES=keycloak vault redis postgres logging
---
> CANDIG_AUTH_MODULES=vault tyk opa federation
> CANDIG_DATA_MODULES=vault redis postgres logging
13c13
< CANDIG_AUTH_DOMAIN=candig.docker.internal
---
> CANDIG_AUTH_DOMAIN=candigauth-demo.uhndata.io
21,22c21
< CANDIG_USER_KEY=email
< # Note: change to preferred_username for client auth grant
---
> CANDIG_USER_KEY=preferred_username
25,26c24,25
< DEFAULT_SITE_ADMIN_USER=${CANDIG_SITE_LOCATION}_site_admin@test.ca
< # Note: change to the preferred_username of your client for client auth grant
---
> #DEFAULT_SITE_ADMIN_USER=${CANDIG_SITE_LOCATION}_site_admin@test.ca
> DEFAULT_SITE_ADMIN_USER=service-account-site_admin
172,175c171,174
< KEYCLOAK_PUBLIC_PROTO=http
< KEYCLOAK_PRIVATE_PROTO=http
< KEYCLOAK_PUBLIC_URL=${KEYCLOAK_PUBLIC_PROTO}://${CANDIG_AUTH_DOMAIN}:${KEYCLOAK_PORT}
< KEYCLOAK_PRIVATE_URL=${KEYCLOAK_PRIVATE_PROTO}://${CANDIG_AUTH_DOMAIN}:${KEYCLOAK_PORT}
---
> KEYCLOAK_PUBLIC_PROTO=https
> KEYCLOAK_PRIVATE_PROTO=https
> KEYCLOAK_PUBLIC_URL=${KEYCLOAK_PUBLIC_PROTO}://${CANDIG_AUTH_DOMAIN}
> KEYCLOAK_PRIVATE_URL=${KEYCLOAK_PRIVATE_PROTO}://${CANDIG_AUTH_DOMAIN}
183c182
< KEYCLOAK_PROXY_HEADERS=none
---
> KEYCLOAK_PROXY_HEADERS=xforwarded
335c334
< OIDC_CHAIN=ROPC
---
> OIDC_CHAIN=CLIENT
```

Then, in [the admin console](https://candigauth-demo.uhndata.io/auth/admin/master/console), do the following:
1. Setup a new client for `site_admin`, the following are the initial settings: 
<img width="992" height="650" alt="image" src="https://github.com/user-attachments/assets/42ce1ccd-5416-4eaf-945c-8b2c2f27dc6d" />

2. On the Client Scopes->site_admin-dedicated: 
<img width="1466" height="650" alt="image" src="https://github.com/user-attachments/assets/5780cba4-02fe-424d-a09b-dd09573385cb" />

3. Add Mapper->By Configuration->Audience:
<img width="1466" height="650" alt="image" src="https://github.com/user-attachments/assets/af726f93-6f3d-47bf-ae00-a401038ea222" />

4. These are the settings you'll want:
<img width="1466" height="706" alt="image" src="https://github.com/user-attachments/assets/9b8fd3fe-93ba-4ce9-bdbf-6ab3929505bc" />
