### PR TITLE
Fix doc links, add link validator

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -3,6 +3,7 @@ import { defineConfig } from 'astro/config';
 import starlight from '@astrojs/starlight';
 import starlightOpenAPI, { openAPISidebarGroups } from 'starlight-openapi'
 import starlightUtils from "@lorenzo_lewis/starlight-utils";
+import starlightLinksValidator from 'starlight-links-validator';
 
 import icon from 'astro-icon';
 
@@ -36,6 +37,7 @@ export default defineConfig({
             icon: 'github', label: 'GitHub', href:'https://github.com/candig/CanDIGv2',
         },],
     plugins: [
+        starlightLinksValidator(),
         starlightUtils({
             navLinks: {
                 leading: { useSidebarLabelled: "headerLinks" },

--- a/docs/package.json
+++ b/docs/package.json
@@ -20,6 +20,7 @@
     "astro-d2": "^0.7.0",
     "astro-icon": "^1.1.1",
     "sharp": "^0.32.5",
+    "starlight-links-validator": "^0.19.1",
     "starlight-openapi": "^0.8.1",
     "tailwindcss": "^3.4.14",
     "typescript": "^5.6.3"

--- a/docs/src/content/docs/deployment/ingest-and-test.md
+++ b/docs/src/content/docs/deployment/ingest-and-test.md
@@ -34,7 +34,7 @@ These tests will not work if the default site administrator has been changed.
 
 ## Manual tests
 
-These tests assume you are on a local deployment with default `.env` values. If not, you will need to update some of the values to suit your deployment. Check that you can see the data portal in your browser at [http://candig.docker.internal:5080](http://candig.docker.internal:5080). If not, refer to the instructions in the [deployment guide](local).
+These tests assume you are on a local deployment with default `.env` values. If not, you will need to update some of the values to suit your deployment. Check that you can see the data portal in your browser at [http://candig.docker.internal:5080](http://candig.docker.internal:5080). If not, refer to the instructions in the [deployment guide](/CanDIGv2/deployment/local).
 
 Check that you can generate a bearer token for user2 with the following call, substituting usernames, secrets and passwords from `env.sh`.
 
@@ -75,6 +75,6 @@ make compose-federation
 
 Synthetic data is ingested as part of the integration tests. By default, this data is deleted after tests are run. If you'd like to keep the data in the platform, ensure the `KEEP_TEST_DATA` variable in your .env file is set to `true`.
 
-If you would like to ingest the data separately, follow the [clinical ingest](../guides/ingest/ingest-clinical#ingesting-clinical-data-into-candig) and [genomic ingest](../guides/ingest/ingest-genomic) instructions using the test files in `lib/candig-ingest/candigv2-ingest/tests`,  using `small_dataset_clinical_ingest.json` for clinical ingest and `small_dataset_genomic_ingest.json` for genomic ingest.
+If you would like to ingest the data separately, follow the [clinical ingest](/CanDIGv2/ingest/ingest-clinical#ingesting-clinical-data-into-candig) and [genomic ingest](/CanDIGv2/ingest/ingest-genomic) instructions using the test files in `lib/candig-ingest/candigv2-ingest/tests`,  using `small_dataset_clinical_ingest.json` for clinical ingest and `small_dataset_genomic_ingest.json` for genomic ingest.
 
 You should now see the ingested data in the [data portal](http://candig.docker.internal:5080).

--- a/docs/src/content/docs/deployment/interact-with-the-stack.md
+++ b/docs/src/content/docs/deployment/interact-with-the-stack.md
@@ -3,7 +3,7 @@ title: Interacting with the stack using Make
 description: A guide to using make commands to interact with the stack
 ---
 
-The [Makefile](Makefile) contains a number of make targets that make interacting the stack more user-friendly. All Makefile commands need to be run from the root directory of the CanDIGv2 repo.
+The `Makefile` contains a number of make targets that make interacting the stack more user-friendly. All Makefile commands need to be run from the root directory of the CanDIGv2 repo.
 
 ## Stopping services
 
@@ -133,11 +133,11 @@ make clean-volumes
 make clean-images
 ```
 
-See the [Makefile](../Makefile) for the exact commands that each of these targets runs.
+See the `Makefile` for the exact commands that each of these targets runs.
 
 ## Rebuild entire stack from scratch
 
-1. Perform any backups of data necessary if in a non-testing environment. (see [backup and restore doc](backup-restore-candig.md) for detailed instructions.)
+1. Perform any backups of data necessary if in a non-testing environment. (see [backup and restore doc](/deployment/backup-restore-candig) for detailed instructions.)
 
 2. Clean up the current containers with `make clean-all`
 

--- a/docs/src/content/docs/deployment/interact-with-the-stack.md
+++ b/docs/src/content/docs/deployment/interact-with-the-stack.md
@@ -137,7 +137,7 @@ See the `Makefile` for the exact commands that each of these targets runs.
 
 ## Rebuild entire stack from scratch
 
-1. Perform any backups of data necessary if in a non-testing environment. (see [backup and restore doc](/deployment/backup-restore-candig) for detailed instructions.)
+1. Perform any backups of data necessary if in a non-testing environment. (see [backup and restore doc](/CanDIGv2/deployment/backup-restore-candig) for detailed instructions.)
 
 2. Clean up the current containers with `make clean-all`
 

--- a/docs/src/content/docs/deployment/local.mdx
+++ b/docs/src/content/docs/deployment/local.mdx
@@ -6,7 +6,7 @@ next: false
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 
-These instructions work for server deployments or local deployments. For local OSX using M1 architecture, there are modification instructions in the [install-os-dependencies-Apple Silicon](#install-os-dependencies) section. For WSL you can follow the linux instructions and follow WSL instructions for firewall file at [update firewall](#update-firewall).
+These instructions work for server deployments or local deployments. For local OSX using M1 architecture, there are modification instructions in the [Dependencies-Apple Silicon](#dependencies) section. For WSL you can follow the linux instructions and follow WSL instructions for firewall file at [update firewall](#update-firewall).
 
 Docker Engine (also known as Docker CE) is recommended over Docker Desktop for linux installations. Docker Desktop works well on Mac installations.
 

--- a/docs/src/content/docs/deployment/local.mdx
+++ b/docs/src/content/docs/deployment/local.mdx
@@ -235,7 +235,7 @@ VENV_OS=<your OS>
 ```
 
 :::danger
-If you are deploying a production level CanDIG deployment that will host real clinical data, see the [production deployment guide](production) for all the settings that need to be updated to ensure the deployed platform is secure.
+If you are deploying a production level CanDIG deployment that will host real clinical data, see the [production deployment guide](/CanDIGv2/deployment/production) for all the settings that need to be updated to ensure the deployed platform is secure.
 :::
 
 <details>
@@ -283,7 +283,7 @@ make init-conda
 
 ### 3.b: Use an existing Conda installation
 
-If you want to use an existing conda installation on your local at the bottom of the [.env](../etc/env/example.env#L310), set `CONDA_INSTALL` to your existing conda installation path
+If you want to use an existing conda installation on your local at the bottom of the [.env](https://github.com/CanDIG/CanDIGv2/blob/3dcfd2b6a47135d9b632db4c4327cb75bab0768a/etc/env/example.env#L342), set `CONDA_INSTALL` to your existing conda installation path
 
 ```bash
 make mkdir # skip most of bin-conda, but need the dir-creating step
@@ -348,7 +348,7 @@ If you want to delete the synthetic data after running these tests, use the comm
 
 If all the tests pass, well done! You have a functional CanDIG stack! 
 
-Next up, you might like to take a look at the documentation for [ingesting data](../guides/ingest) as well as [Interacting with the stack using Make](interact-with-the-stack) and if you are a developer: [how to modify code and test changes](../technical/docker-and-submodules) in the context of the CanDIG stack.
+Next up, you might like to take a look at the documentation for [ingesting data](/CanDIGv2/ingest) as well as [Interacting with the stack using Make](/CanDIGv2/deployment/interact-with-the-stack). If you are looking to set up a Production node, please read through the [production deployment guide](/CanDIGv2/deployment/production).
 
 ## Troubleshooting
 

--- a/docs/src/content/docs/deployment/production.mdx
+++ b/docs/src/content/docs/deployment/production.mdx
@@ -8,7 +8,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 import { Steps } from '@astrojs/starlight/components';
 import { Aside } from '@astrojs/starlight/components';
 
-Apart from the basic steps in the [Local Deployment Guide](local) to get the CanDIG stack up and running, there are additional settings and security recommendations that need to set up in a production level environment. We provide the following as general advice, but it is important for all CanDIG deployers to also consult with their institutional infrastructure security personnel to ensure that their deployment meets the necessary level of data security.
+Apart from the basic steps in the [Local Deployment Guide](/CanDIGv2/deployment/local) to get the CanDIG stack up and running, there are additional settings and security recommendations that need to set up in a production level environment. We provide the following as general advice, but it is important for all CanDIG deployers to also consult with their institutional infrastructure security personnel to ensure that their deployment meets the necessary level of data security.
 
 ## Stable branch
 
@@ -67,7 +67,7 @@ The following default settings in the `.env` file should be changed when deployi
 | `CANDIG_PRODUCTION_MODE=1`                                                               | Turn on Production mode  |
 | `LOCAL_IP_ADDR=192.168.x.x`                                                              | May need to set to your public IP, not always needed |
 | `FEDERATION_SELF_SERVER_ID=<unique-node-name>`                                           |  e.g. UHN-prod, BCGSC-prod. Uniquely identifies your node within the CanDIG federation, can be `${CANDIG_SITE_LOCATION}` |
-| `FEDERATION_SELF_SERVER` - update province, province-code see [section below](setting-location-information) | Ensures site displays properly on the map and can be federated |
+| `FEDERATION_SELF_SERVER` - update province, province-code see [section below](#setting-location-information) | Ensures site displays properly on the map and can be federated |
 | `KEYCLOAK_CLIENT_ID=<your-keycloak-identifier>`                                          | Optional to change this, more for consistency than necessity |
 | `KEYCLOAK_PUBLIC_PROTO=https`                                                            | change to https for prod |
 | `KEYCLOAK_PUBLIC_URL=${KEYCLOAK_PUBLIC_PROTO}://${CANDIG_AUTH_DOMAIN}`                   | Keycloak public url shouldn't have port|
@@ -210,12 +210,12 @@ Run `python site_admin_token.py`. You should be prompted for your actual site ad
 Keep the site admin user and password secure at all times.
 
 :::tip
-See [User roles](user-roles/roles-overview) for a full description of the available user roles in CanDIG.
+See [User roles](/CanDIGv2/user-roles/roles-overview) for a full description of the available user roles in CanDIG.
 :::
 
 ### Adding a site curator
 
-See [User Roles](user-roles/assign-roles#assign-the-site-curator-role)
+See [User Roles](/CanDIGv2/user-roles/assign-roles#assign-the-site-curator-role)
 
 ## Connecting Keycloak to institutional LDAP
 
@@ -229,9 +229,9 @@ Federation is a two way process, where you need to register another server with 
 
 Once two nodes are federated, summary data from federated nodes will appear in both nodes' data portals and will be viewable by all users who are able to login.
 
-Access to patient level data through specific program authorization is managed by the node that hosts the data for that program. For example, if a user from UHN needs to be given authorization to a program hosted within the BC node, a site administrator, site curator or program curator (with authorization for that program) from BC will need to [add that UHN user as a team member](../guides/ingest/register-programs) to that program within the BC CanDIG node. Alternately, if the UHN user was granted access through a DAC process,  
+Access to patient level data through specific program authorization is managed by the node that hosts the data for that program. For example, if a user from UHN needs to be given authorization to a program hosted within the BC node, a site administrator, site curator or program curator (with authorization for that program) from BC will need to [add that UHN user as a team member](/CanDIGv2/ingest/register-programs) to that program within the BC CanDIG node. Alternately, if the UHN user was granted access through a DAC process,  
 
 ## Backing up production data
 
-It is not expected that a CanDIG instance would hold the only copy of any ingested data. However, recognising that the ETL and ingest process takes significant time and effort, it is a good idea to regularly backup all data stored in CanDIG. Steps for how to do this can be found in [Backing up and restoring CanDIG data](backup-restore-candig.md)
+It is not expected that a CanDIG instance would hold the only copy of any ingested data. However, recognising that the ETL and ingest process takes significant time and effort, it is a good idea to regularly backup all data stored in CanDIG. Steps for how to do this can be found in [Backing up and restoring CanDIG data](/CanDIGv2/deployment/backup-restore-candig)
 

--- a/docs/src/content/docs/deployment/update-candig.mdx
+++ b/docs/src/content/docs/deployment/update-candig.mdx
@@ -16,15 +16,15 @@ The process for updating depends on the changes contained in a particular releas
 
 <Steps>
 
-1. Backup your existing deployment using the steps on the page: [Backing up and restoring CanDIG data](../backup-restore-candig). This should be done regardless of wheteher you think the deployment will destroy any data, just in case anything goes wrong. Things you will want to back up are:
-    - ingested genomic and clinical data - Guide here: [Back up postgres databases](../backup-restore-candig/#backing-up-postgres-databases)
-    - log files - Guide here: [backup logfiles](../backup-restore-candig/#backing-up-logs)
-    - user authorizations - Guide here: [backup secrets and authorizations](../backup-restore-candig/#backing-up-secrets-and-authorization-data)
+1. Backup your existing deployment using the steps on the page: [Backing up and restoring CanDIG data](/CanDIGv2/deployment/backup-restore-candig). This should be done regardless of wheteher you think the deployment will destroy any data, just in case anything goes wrong. Things you will want to back up are:
+    - ingested genomic and clinical data - Guide here: [Back up postgres databases](/CanDIGv2/deployment/backup-restore-candig/#backing-up-postgres-databases)
+    - log files - Guide here: [backup logfiles](/CanDIGv2/deployment/backup-restore-candig/#backing-up-logs)
+    - user authorizations - Guide here: [backup secrets and authorizations](/CanDIGv2/deployment/backup-restore-candig/#backing-up-secrets-and-authorization-data)
     - federation details (if your node is federated with other nodes) - see expandable section below:
         <details>
         <summary>How to save currently stored federation information</summary>
         <Steps>
-        1. [Get a site admin token](../../user-roles/assign-roles/#getting-an-api-token) and in a terminal session, store in a variable called `TOKEN`, store your candig domain in a variable called `CANDIG_URL`
+        1. [Get a site admin token](/CanDIGv2/user-roles/assign-roles/#getting-an-api-token) and in a terminal session, store in a variable called `TOKEN`, store your candig domain in a variable called `CANDIG_URL`
 
         2. Call the GET method to list all currently federated servers:
             ```bash
@@ -134,7 +134,7 @@ The process for updating depends on the changes contained in a particular releas
     make build-all
     ```
 
-8. If you performed a destructive rebuild, it will be necessary to reingest and restore backed up data following the [guide](../backup-restore-candig). This includes any clinical and genomic data as well as information about user authorizations. Federating to other nodes will also need to be reinitiated with all other nodes in the network. Federating with nodes at a different stable version may not be possible.
+8. If you performed a destructive rebuild, it will be necessary to reingest and restore backed up data following the [guide](/CanDIGv2/deployment/backup-restore-candig). This includes any clinical and genomic data as well as information about user authorizations. Federating to other nodes will also need to be reinitiated with all other nodes in the network. Federating with nodes at a different stable version may not be possible.
 
     :::note
     Depending on the changes that were made, it may not be possible to directly restore from backup, e.g. if the underlying structure of the postgres databases has changed, the data will need to be reingested through ingest, rather than restored directly to the database.
@@ -204,7 +204,7 @@ The process for updating depends on the changes contained in a particular releas
     make test-integration
     ```
 
-    If tests fail, check out the [troubleshooting section](stack-troubleshooting) or [reach out for help](https://github.com/CanDIG/CanDIGv2/issues/new/choose).
+    If tests fail, check out the [troubleshooting section](/CanDIGv2/deployment/stack-troubleshooting) or [reach out for help](https://github.com/CanDIG/CanDIGv2/issues/new/choose).
 
 10. Reinstate federation with other nodes
 

--- a/docs/src/content/docs/deployment/update-candig.mdx
+++ b/docs/src/content/docs/deployment/update-candig.mdx
@@ -16,15 +16,15 @@ The process for updating depends on the changes contained in a particular releas
 
 <Steps>
 
-1. Backup your existing deployment using the steps on the page: [Backing up and restoring CanDIG data](backup-restore-candig). This should be done regardless of wheteher you think the deployment will destroy any data, just in case anything goes wrong. Things you will want to back up are:
-    - ingested genomic and clinical data - Guide here: [Back up postgres databases](backup-restore-candig/#backing-up-postgres-databases)
-    - log files - Guide here: [backup logfiles](backup-restore-candig/#backing-up-logs)
-    - user authorizations - Guide here: [backup secrets and authorizations](backup-restore-candig/#backing-up-secrets-and-authorization-data)
+1. Backup your existing deployment using the steps on the page: [Backing up and restoring CanDIG data](../backup-restore-candig). This should be done regardless of wheteher you think the deployment will destroy any data, just in case anything goes wrong. Things you will want to back up are:
+    - ingested genomic and clinical data - Guide here: [Back up postgres databases](../backup-restore-candig/#backing-up-postgres-databases)
+    - log files - Guide here: [backup logfiles](../backup-restore-candig/#backing-up-logs)
+    - user authorizations - Guide here: [backup secrets and authorizations](../backup-restore-candig/#backing-up-secrets-and-authorization-data)
     - federation details (if your node is federated with other nodes) - see expandable section below:
         <details>
         <summary>How to save currently stored federation information</summary>
         <Steps>
-        1. [Get a site admin token](/user-roles/assign-roles/#getting-an-api-token) and in a terminal session, store in a variable called `TOKEN`, store your candig domain in a variable called `CANDIG_URL`
+        1. [Get a site admin token](../../user-roles/assign-roles/#getting-an-api-token) and in a terminal session, store in a variable called `TOKEN`, store your candig domain in a variable called `CANDIG_URL`
 
         2. Call the GET method to list all currently federated servers:
             ```bash
@@ -134,7 +134,7 @@ The process for updating depends on the changes contained in a particular releas
     make build-all
     ```
 
-8. If you performed a destructive rebuild, it will be necessary to reingest and restore backed up data following the [guide](backup-restore-candig). This includes any clinical and genomic data as well as information about user authorizations. Federating to other nodes will also need to be reinitiated with all other nodes in the network. Federating with nodes at a different stable version may not be possible.
+8. If you performed a destructive rebuild, it will be necessary to reingest and restore backed up data following the [guide](../backup-restore-candig). This includes any clinical and genomic data as well as information about user authorizations. Federating to other nodes will also need to be reinitiated with all other nodes in the network. Federating with nodes at a different stable version may not be possible.
 
     :::note
     Depending on the changes that were made, it may not be possible to directly restore from backup, e.g. if the underlying structure of the postgres databases has changed, the data will need to be reingested through ingest, rather than restored directly to the database.

--- a/docs/src/content/docs/explore.mdx
+++ b/docs/src/content/docs/explore.mdx
@@ -14,17 +14,17 @@ import { LinkCard, Card, CardGrid } from '@astrojs/starlight/components';
 <CardGrid stagger>
 	<LinkCard 
 		title="Overview of Summary dashboard" 
-		href="summary"
+		href="/CanDIGv2/explore/summary"
 		description="Intro to the summary dashboard"
 	/>
 	<LinkCard 
 		title="Querying in CanDIG"
-		href="clinical-genomic-search"
+		href="/CanDIGv2/explore/clinical-genomic-search"
 		description="How to query in CanDIG."
 	/>
 	<LinkCard 
 		title="Completeness"
-		href="completeness"
+		href="/CanDIGv2/explore/completeness"
 		description="Explanation of completeness in CanDIG"
 	/>
 </CardGrid>

--- a/docs/src/content/docs/guides/summary.mdx
+++ b/docs/src/content/docs/guides/summary.mdx
@@ -1,0 +1,4 @@
+---
+title: Summary page
+description: Overview of the Summary page
+---

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -16,27 +16,27 @@ Choose a category below or use the search box above to find what you are looking
 <CardGrid>
 	<LinkCard
 		title="I want to deploy CanDIG"
-		href="deployment/local"
+		href="/CanDIGv2/deployment/local"
 		description="Read guides on how to install CanDIG in a development or production setting."
 	/>
 	<LinkCard
 		title="I want to submit data to CanDIG"
-		href="ingest"
+		href="/CanDIGv2/ingest"
 		description="Read walk-throughs on how to submit/ingest your data to a CanDIG instance."
 	/>
 	<LinkCard
 		title="I want to explore data in CanDIG"
-		href="ingest"
+		href="/CanDIGv2/explore"
 		description="Read walk-throughs on how to explore data across the CanDIG network."
 	/>
 	<LinkCard
 		title="I want to manage user roles in CanDIG"
-		href="user-roles/roles-overview"
+		href="/CanDIGv2/user-roles/roles-overview"
 		description="Learn how to give users permissions to perform tasks and access data in CanDIG."
 	/>
 	<LinkCard
 		title="Technical docs"
-		href="technical/architecture"
+		href="/CanDIGv2/technical/architecture"
 		description="Read technical information about CanDIG including API docs"
 	/>
 </CardGrid>

--- a/docs/src/content/docs/ingest.mdx
+++ b/docs/src/content/docs/ingest.mdx
@@ -32,32 +32,32 @@ Anyone intending to upload data to a CanDIG instance.
 <CardGrid stagger>
 	<LinkCard
 		title="Step 1. Prepare clinical data"
-		href="prepare-clinical"
+		href="/CanDIGv2/ingest/prepare-clinical"
 		description="Prepare your clinical data for ingest"
 	/>
 	<LinkCard
 		title="Step 2. Register programs"
-		href="register-programs"
+		href="/CanDIGv2/ingest/register-programs"
 		description="Register the programs you intend to ingest."
 	/>
 	<LinkCard
 		title="Step 3. Ingest clinical data"
-		href="ingest-clinical"
+		href="/CanDIGv2/ingest/ingest-clinical"
 		description="Ingest your clinical data."
 	/>
 	<LinkCard
 		title="Step 4. Prepare Genomic data"
-		href="prepare-genomic"
+		href="/CanDIGv2/ingest/prepare-genomic"
 		description="Prepare you genomic data for ingest."
 	/>
 	<LinkCard
 		title="Step 5. Link Genomic data"
-		href="ingest-genomic"
+		href="/CanDIGv2/ingest/ingest-genomic"
 		description="Link your clinical data to your genomic data."
 	/>
   <LinkCard
 		title="I need help"
-		href="ingest-help"
+		href="/CanDIGv2/ingest/ingest-help"
 		description="Get help with all aspects of ingest."
 	/>
 

--- a/docs/src/content/docs/ingest/ingest-help.mdx
+++ b/docs/src/content/docs/ingest/ingest-help.mdx
@@ -179,4 +179,4 @@ When attempting clinical data ingest into katsu, if you get a response such as b
 }}
 ```
 
-It means you have not yet registered your program before ingesting. Please follow the instructions in [Register Programs](register-programs/) to submit a program authorization before attempting clinical ingest again.
+It means you have not yet registered your program before ingesting. Please follow the instructions in [Register Programs](/CanDIGv2/ingest/register-programs/) to submit a program authorization before attempting clinical ingest again.

--- a/docs/src/content/docs/ingest/prepare-genomic.mdx
+++ b/docs/src/content/docs/ingest/prepare-genomic.mdx
@@ -17,7 +17,7 @@ All genomic data files need to be able to be ‘seen’  by the running `htsget_
 Systems may need information in the drop-downs below:
 
 <details>
-<summary>Configuring s3 authorisation</summary>
+<summary>Configuring s3 authorization</summary>
 
 #### Pre-requisites:
 
@@ -196,7 +196,7 @@ The file should contain an array of dictionaries, where each item represents a s
 - Access methods can either be of the format `s3://[endpoint]/[bucket name]` or `file:///[directory relative to root on htsget container]`.
 - `submitter_sample_id`(s) are the (mandatory) links to the `Sample Registration objects uploaded during clinical data ingest.
 - `index` is the file location and name of the index file; for instance a tabix (`tbi`) or cram index (`crai`)
-- If an S3 bucket access method is provided, assuming you have properly added the S3 credentials to vault [(see above)](#Add-s3-credentials-to-vault), the service will scan the S3 bucket to ensure the relevant files are present.
+- If an S3 bucket access method is provided, assuming you have properly added the S3 credentials to vault [(see `Configureing s3 authorization`above)](#a-configure-connection-to-genomic-data-sources), the service will scan the S3 bucket to ensure the relevant files are present.
 - There is no validation that the genomic files exist locally or are mounted to htsget. If the local (`file:///`) method is used it is important to check all files are present before proceeding with ingest.
 
 :::caution

--- a/docs/src/content/docs/ingest/register-programs.mdx
+++ b/docs/src/content/docs/ingest/register-programs.mdx
@@ -9,7 +9,7 @@ tableOfContents:
 import { Icon } from 'astro-icon/components';
 import { Steps } from '@astrojs/starlight/components';
 
-Before any program can be ingested into CanDIG, it needs to be registered. To first register a program, you must be either a site admin or a site curator. During program registration, you can also assign program curators and team members to the program. For more information about user roles in CanDIG, see [User roles in CanDIG](../deployment/user-roles). If you need to be made a site curator or program curator, please contact your local site administrator to assign your user profile the appropriate role.
+Before any program can be ingested into CanDIG, it needs to be registered. To first register a program, you must be either a site admin or a site curator. During program registration, you can also assign program curators and team members to the program. For more information about user roles in CanDIG, see [User roles in CanDIG](/CanDIGv2/user-roles/roles-overview). If you need to be made a site curator or program curator, please contact your local site administrator to assign your user profile the appropriate role.
 
 ## How to register a program
 

--- a/docs/src/content/docs/technical.mdx
+++ b/docs/src/content/docs/technical.mdx
@@ -17,7 +17,7 @@ import { LinkCard, Card, CardGrid } from '@astrojs/starlight/components';
 <CardGrid stagger>
 	<LinkCard 
 		title="CanDIG Architecture" 
-		href="architecture"
+		href="/CanDIGv2/technical/architecture"
 		description="Prepare your clinical data for ingest"
 	/>
 </CardGrid>

--- a/docs/src/content/docs/technical/architecture.mdx
+++ b/docs/src/content/docs/technical/architecture.mdx
@@ -51,7 +51,7 @@ The following table lists the individual repos for each service and helper libra
 | CanDIG Query service             | [`candigv2-query`](https://github.com/CanDIG/candigv2-query)                   | Manages front-end querying of services |
 | CanDIG logging            | [candigv2-logging](https://github.com/CanDIG/candigv2-logging)        | Logging package to unify logging across all services|
 
-As well as in-house developed services, the CanDIG stack relies on external software which is configured to work within the stack, configurations are found in the [`/lib`](/lib) folder for each software, these include:
+As well as in-house developed services, the CanDIG stack relies on external software which is configured to work within the stack, configurations are found in the `/lib` folder for each software, these include:
 
 | Service/Component Name                  | Role                                 |
 |-----------------------------------------|--------------------------------------|

--- a/docs/src/content/docs/user-roles.mdx
+++ b/docs/src/content/docs/user-roles.mdx
@@ -14,17 +14,17 @@ import { LinkCard, Card, CardGrid } from '@astrojs/starlight/components';
 <CardGrid stagger>
 	<LinkCard 
 		title="Overview of User roles" 
-		href="roles-overview"
+		href="/CanDIGv2/user-roles/roles-overview"
 		description="Intro and overview of user roles"
 	/>
 	<LinkCard 
 		title="How to assign roles"
-		href="assign-roles"
+		href="/CanDIGv2/user-roles/assign-roles"
 		description="How to use CanDIG APIs to assign roles to users."
 	/>
 	<LinkCard 
 		title="DAC authorizations"
-		href="dac-authorization"
+		href="/CanDIGv2/user-roles/dac-authorization"
 		description="How to give users DAC authorization for specific datasets"
 	/>
 </CardGrid>

--- a/docs/src/content/docs/user-roles/assign-roles.mdx
+++ b/docs/src/content/docs/user-roles/assign-roles.mdx
@@ -6,7 +6,7 @@ tableOfContents: true
 
 import { Badge } from '@astrojs/starlight/components';
 
-Detailed information about what each role means can be found on the [Roles overview](roles-overview) page. This page walks through how to assign, approve and reject various user roles. All user management is done via API calls, there is currently no graphical user interface for this process. If using our API regularly, you may want to set up an API client such as [Postman](https://www.postman.com/), [Bruno](https://www.usebruno.com/) or [RapidAPI](https://paw.cloud/) to help with managing your frequently used API calls.
+Detailed information about what each role means can be found on the [Roles overview](/CanDIGv2/user-roles/roles-overview) page. This page walks through how to assign, approve and reject various user roles. All user management is done via API calls, there is currently no graphical user interface for this process. If using our API regularly, you may want to set up an API client such as [Postman](https://www.postman.com/), [Bruno](https://www.usebruno.com/) or [RapidAPI](https://paw.cloud/) to help with managing your frequently used API calls.
 
 ## Getting an API token
 
@@ -37,7 +37,7 @@ TOKEN=ey-pasted-jwt
 
 ## Add one or more pre-approved users <Badge text="Site admin" variant="caution" />
 
-This can only be performed by a Site admin. The Site admin can add one or many users to the list via a post to the `/ingest/user/preapproved` endpoint. The first time these users login to the CanDIG data portal, they will see a page with a 'Request Access' button but will be automatically approved as CanDIG Authorized Users after clicking the button. [This diagram](roles-overview/#pre-approval-flow) presents visual representation of this process.
+This can only be performed by a Site admin. The Site admin can add one or many users to the list via a post to the `/ingest/user/preapproved` endpoint. The first time these users login to the CanDIG data portal, they will see a page with a 'Request Access' button but will be automatically approved as CanDIG Authorized Users after clicking the button. [This diagram](/CanDIGv2/user-roles/roles-overview/#pre-approval-flow) presents visual representation of this process.
 
 First [get a token](#getting-an-api-token), then:
 
@@ -97,7 +97,7 @@ curl --request GET \
 
 ## Approve or reject a user that has requested access <Badge text="Site admin" variant="caution" />
 
-This can only be performed by a Site admin. Unauthorized users can request access by clicking a button in the CanDIG Data portal. They will only see this button if they are unauthorized and are not currently on the pending users list. Clicking this button causes the user to be added to the `pending users` list. A Site admin then needs to approve these users so they can become [CanDIG Authorized Users](roles-overview#1-candig-authorized-user). [This diagram](roles-overview#request-flow) demonstrates this process visually.
+This can only be performed by a Site admin. Unauthorized users can request access by clicking a button in the CanDIG Data portal. They will only see this button if they are unauthorized and are not currently on the pending users list. Clicking this button causes the user to be added to the `pending users` list. A Site admin then needs to approve these users so they can become [CanDIG Authorized Users](/CanDIGv2/user-roles/roles-overview#5-candig-authorized-user). [This diagram](/CanDIGv2/user-roles/roles-overview#request-flow) demonstrates this process visually.
 
 First [get a token](#getting-an-api-token), then:
 

--- a/docs/src/content/docs/user-roles/assign-roles.mdx
+++ b/docs/src/content/docs/user-roles/assign-roles.mdx
@@ -39,7 +39,7 @@ TOKEN=ey-pasted-jwt
 
 This can only be performed by a Site admin. The Site admin can add one or many users to the list via a post to the `/ingest/user/preapproved` endpoint. The first time these users login to the CanDIG data portal, they will see a page with a 'Request Access' button but will be automatically approved as CanDIG Authorized Users after clicking the button. [This diagram](roles-overview/#pre-approval-flow) presents visual representation of this process.
 
-First [get a token](#getting-a-token), then:
+First [get a token](#getting-an-api-token), then:
 
 1. You can check the current list of preapproved users with `GET`:
 
@@ -99,7 +99,7 @@ curl --request GET \
 
 This can only be performed by a Site admin. Unauthorized users can request access by clicking a button in the CanDIG Data portal. They will only see this button if they are unauthorized and are not currently on the pending users list. Clicking this button causes the user to be added to the `pending users` list. A Site admin then needs to approve these users so they can become [CanDIG Authorized Users](roles-overview#1-candig-authorized-user). [This diagram](roles-overview#request-flow) demonstrates this process visually.
 
-First [get a token](#getting-a-token), then:
+First [get a token](#getting-an-api-token), then:
 
 ### List pending users
 
@@ -199,7 +199,7 @@ This can only be done by a Site admin. If a user has CanDIG Authorized User stat
 Assuming your CanDIG deployment is connected to your institutional identity provider, if a user loses access to their institutional credentials they will also no longer be able to login to CanDIG.
 :::
 
-First [get a token](#getting-a-token) following the guide above, then:
+First [get a token](#getting-an-api-token) following the guide above, then:
 
 ```bash
 curl --request DELETE \
@@ -215,7 +215,7 @@ The user will then no longer be able to login and explore the CanDIG data portal
 
 This can only be done by a Site admin.
 
-Follow the steps in [Getting a Token](#getting-a-token) above then:
+Follow the steps in [Getting a Token](#getting-an-api-token) above then:
 
 1. POST to the `site-role` endpoint in ingest to assign a user the Site curator role, e.g. with user1@test.ca
 

--- a/docs/src/content/docs/user-roles/roles-overview.mdx
+++ b/docs/src/content/docs/user-roles/roles-overview.mdx
@@ -40,7 +40,7 @@ A summary of what each user role can do within a deployed CanDIG site is in the 
 A `Site admin` automatically has access to read, submit and delete all data in the platform. They have special permissions to use particular endpoints that other user roles cannot access. They are also responsible for assigning roles to users and approving pending access requests. Additionally, they have the ability to 'pre-approve' users.
 
 :::danger
-A default `Site admin` is set up when the CanDIGv2 stack is first deployed, this should be changed to a real user as soon as possible if the deployment will be used for submitting real data. [See instructions here](../../deployment/production#change-the-default-site-admin).
+A default `Site admin` is set up when the CanDIGv2 stack is first deployed, this should be changed to a real user as soon as possible if the deployment will be used for submitting real data. [See instructions here](/CanDIGv2/deployment/production#change-the-default-site-admin).
 :::
 
 ## 2. Site curator

--- a/docs/src/content/docs/user-roles/roles-overview.mdx
+++ b/docs/src/content/docs/user-roles/roles-overview.mdx
@@ -40,7 +40,7 @@ A summary of what each user role can do within a deployed CanDIG site is in the 
 A `Site admin` automatically has access to read, submit and delete all data in the platform. They have special permissions to use particular endpoints that other user roles cannot access. They are also responsible for assigning roles to users and approving pending access requests. Additionally, they have the ability to 'pre-approve' users.
 
 :::danger
-A default `Site admin` is set up when the CanDIGv2 stack is first deployed, this should be changed to a real user as soon as possible if the deployment will be used for submitting real data. [See instructions here](/deployment/production#change-the-default-site-admin).
+A default `Site admin` is set up when the CanDIGv2 stack is first deployed, this should be changed to a real user as soon as possible if the deployment will be used for submitting real data. [See instructions here](../../deployment/production#change-the-default-site-admin).
 :::
 
 ## 2. Site curator


### PR DESCRIPTION
Thanks to reported by @rjiang9 we had quite a lot of broken links throughout the documentation

* Added internal links validator so docs build will fail if any invalid links
* Fixed all invalid internal links

To test:
* checkout branch
* `cd docs`
* run `npm run build` and note message:
```
validating links 
15:17:09 ✓ All internal links are valid.
```
* checkout branch
* `cd docs`
* run `npm run dev` 
* Try first few links on http://localhost:4322/CanDIGv2/deployment/update-candig/ and compare to broken links on https://candig.github.io/CanDIGv2/deployment/update-candig/ 