### PR TITLE
Hotfix: build ingest before federation

### DIFF
--- a/docs/src/content/docs/deployment/production.mdx
+++ b/docs/src/content/docs/deployment/production.mdx
@@ -79,6 +79,7 @@ The following default settings in the `.env` file should be changed when deployi
 | `CANDIG_DATA_PORTAL_URL=https://${CANDIG_DOMAIN}:${CANDIG_DATA_PORTAL_PORT}/data-portal` | ensure dataportal url has https |
 | `CANDIG_DATA_PORTAL_SUPPORT_EMAIL=YOUR_SITE_ADMIN_SUPPORT_EMAIL` | Update the value to a valid email that will deal with user requests to access to the portal |
 | `DIR_PERMISSIONS=775` | You may not need to change the default here but be aware that this gives anyone in the group of the person that deployed the current instance the ability to recompose services and rebuild the stack |
+|`CANDIG_USER_KEY=preferred_username`| You should not need to edit this. Please contact a CanDIG developer for advice if you think this needs to be changed|
 
 
 ### Setting location information

--- a/etc/env/example-production.env
+++ b/etc/env/example-production.env
@@ -2,7 +2,7 @@
 # - - -
 
 # site options
-CANDIG_MODULES=logging keycloak vault redis postgres drs htsget katsu rnaget query tyk opa federation candig-ingest candig-data-portal
+CANDIG_MODULES=logging keycloak vault redis postgres drs htsget katsu rnaget query tyk opa candig-ingest federation candig-data-portal
     #candig-api drs-server wes-server monitoring
 CANDIG_AUTH_MODULES=keycloak vault tyk opa federation
 CANDIG_DATA_MODULES=keycloak vault redis postgres logging
@@ -18,7 +18,7 @@ CANDIG_DEBUG_MODE=0
 CANDIG_PRODUCTION_MODE=1
 CANDIG_VERSION=v7.0.0
 
-# this is the unique key used by your site IDP to identify users.
+# this is the unique key used by your site IDP to identify users. You probably should not change this.
 CANDIG_USER_KEY=preferred_username
 
 # default name for built-in site admin

--- a/etc/env/example.env
+++ b/etc/env/example.env
@@ -2,7 +2,7 @@
 # - - -
 
 # site options
-CANDIG_MODULES=logging keycloak vault redis postgres drs htsget katsu rnaget query tyk opa federation candig-ingest candig-data-portal
+CANDIG_MODULES=logging keycloak vault redis postgres drs htsget katsu rnaget query tyk opa candig-ingest federation candig-data-portal
     #candig-api drs-server wes-server monitoring
 CANDIG_AUTH_MODULES=keycloak vault tyk opa federation
 CANDIG_DATA_MODULES=keycloak vault redis postgres logging


### PR DESCRIPTION
Federation needs to set up using CanDIG-authorized users, and that happens during ingest setup.