### PR TITLE
DRS needs access to aws secrets

### DIFF
--- a/lib/drs/drs_setup.sh
+++ b/lib/drs/drs_setup.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -Euo pipefail
+
+LOGFILE=$PWD/tmp/progress.txt
+
+# This script runs after the container is composed.
+
+echo ">> waiting for drs to start"
+drs=$(docker ps --format "{{.Names}}" | grep drs)
+while [ $? -ne 0 ]
+do
+  echo "..."
+  sleep 1
+  drs=$(docker ps --format "{{.Names}}" | grep drs)
+done
+
+python settings.py
+source env.sh
+bash $PWD/create_service_store.sh "drs"

--- a/lib/vault/vault_setup.sh
+++ b/lib/vault/vault_setup.sh
@@ -166,6 +166,9 @@ docker exec $vault sh -c "echo 'path \"opa/data\" {capabilities = [\"update\", \
 # Htsget needs access to the ingest store's aws path:
 docker exec $vault sh -c "echo 'path \"candig-ingest/aws/*\" {capabilities = [\"read\"]}' >> htsget-policy.hcl; vault policy write htsget htsget-policy.hcl"
 
+# DRS needs access to the ingest store's aws path:
+docker exec $vault sh -c "echo 'path \"candig-ingest/aws/*\" {capabilities = [\"read\"]}' >> drs-policy.hcl; vault policy write drs drs-policy.hcl"
+
 # Opa needs access to the federation store's external_services path:
 docker exec $vault sh -c "echo 'path \"federation/external_services\" {capabilities = [\"read\"]}' >> opa-policy.hcl; vault policy write opa opa-policy.hcl"
 


### PR DESCRIPTION
DRS needs access to the AWS credentials stored in ingest's store in order to download files.

Already deployed on UHN prod and it works.