### PR TITLE
CanDIG/candigv2-ingest merging: DIG-2298: Do not overwrite previously-ingested items by default

### DIFF
--- a/etc/tests/integration/test_integration.py
+++ b/etc/tests/integration/test_integration.py
@@ -601,7 +601,7 @@ def test_ingest_not_admin_htsget():
         "Content-Type": "application/json; charset=utf-8",
     }
     # since we're only ingesting for a quick test before we delete again, don't bother indexing
-    response = requests.post(f"{ENV['CANDIG_URL']}/ingest/ingest", headers=headers, json=test_data, params={"do_not_index": True})
+    response = requests.post(f"{ENV['CANDIG_URL']}/ingest/ingest", headers=headers, json=test_data)
     try:
         queue_id = response.json()["queue_id"]
     except Exception as e:


### PR DESCRIPTION
PR triggered by update to develop branch on CanDIG/candigv2-ingest. Commit hash: `58562cd5cfb02c5f4c066e24050b74de389b5fa9`. PR link: [#202](https://github.com/CanDIG/candigv2-ingest/pull/202)