### PR TITLE
DIG-2316: Log relevant messages from vault instead of saving vault audit log

### DIFF
--- a/.github/workflows/candig-testing.yml
+++ b/.github/workflows/candig-testing.yml
@@ -81,9 +81,6 @@ jobs:
               docker cp candigv2_candig-ingest_1:/home/candig/tmp tmp/ingest 2>&1
               mkdir tmp/index
               docker cp candigv2_htsget_1:/home/candig/tmp tmp/index 2>&1
-      - name: Save vault audit logs
-        if: always()
-        run: docker cp candigv2_vault-runner_1:/vault/vault-audit.log tmp/vault_audit.log 2>&1
       - name: Save container and error logs as artifact
         if: always()
         uses: actions/upload-artifact@v4
@@ -92,7 +89,6 @@ jobs:
           path: |
                 tmp/progress.txt
                 tmp/container_logs.txt
-                tmp/vault_audit.log
                 tmp/ingest
                 tmp/index
 

--- a/etc/venv/requirements.txt
+++ b/etc/venv/requirements.txt
@@ -7,7 +7,7 @@ pytest>=8.3.3
 pytz>=2024.2
 minio>=7.2.12
 GitPython>=3.1.43
-candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.8.4
+candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.9.0
 candigv2-logging@git+https://github.com/CanDIG/candigv2-logging.git@v1.0.3
 clinical_etl@git+https://github.com/CanDIG/clinical_ETL_code.git@v3.1.2
 werkzeug>=2.3.8 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/lib/vault/vault_setup.sh
+++ b/lib/vault/vault_setup.sh
@@ -110,9 +110,9 @@ docker exec $vault sh -c "vault login ${key_root}"
 
 # configuration
 # audit file
-echo
-echo ">> enabling audit file"
-docker exec $vault sh -c "vault audit enable file file_path=/vault/vault-audit.log"
+# echo
+# echo ">> enabling audit file"
+# docker exec $vault sh -c "vault audit enable file file_path=/vault/vault-audit.log"
 
 # enable approle
 echo


### PR DESCRIPTION
Only a few transactions that are logged in the vault audit log are actually relevant to CanDIG; we added them as logged messages in authx v2.9.0 so now we can disable direct Vault audit logs.

I looked through the github test logs and it looks like all of the tokens are correctly hidden and the logging is working correctly. NB: there are logging messages like 
```
2026-04-17T18:52:29+00:00	candigv2_federation_1	{"source":"stdout","log":"level: DEBUG, file: urllib3.connectionpool, log: http://vault:8200 \"GET /v1/federation/token/9556141c-3a8e-11f1-ada1-3614914dfab3 HTTP/1.1\" 200 212"}
```
which do reveal the secret value, but those have always been there when Vault's docker-compose specifies DEBUG_MODE as true.