### PR TITLE
DIG-1809: Automate adding a site logo to the data portal

### DIFF
--- a/replace_logo.sh
+++ b/replace_logo.sh
@@ -29,7 +29,7 @@ portal_dir="$script_dir/lib/candig-data-portal/candig-data-portal"
 # Figure out what to overwrite
 extension="${src##*.}"
 case "$choice" in
-    header)   dest="$portal_dir/src/assets/images/logo.$extension" ;;
+    header) dest="$portal_dir/src/assets/images/logo.$extension" ;;
     footer) dest="$portal_dir/src/assets/images/logo-notext.$extension" ;;
     -h|--help) usage ;;
     *) echo "Error: unknown target '$choice'" >&2; usage ;;
@@ -40,11 +40,6 @@ if [[ ! -f "$src" ]]; then
     echo "Error: source file '$src' does not exist" >&2
     exit 1
 fi
-
-# if [[ ! -f "$dest" ]]; then
-#     echo "Error: destination '$dest' does not exist (portal layout may have changed)" >&2
-#     exit 1
-# fi
 
 # Copy and echo
 cp -- "$src" "$dest"

--- a/replace_logo.sh
+++ b/replace_logo.sh
@@ -27,9 +27,10 @@ script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 portal_dir="$script_dir/lib/candig-data-portal/candig-data-portal"
 
 # Figure out what to overwrite
+extension="${src##*.}"
 case "$choice" in
-    header)   dest="$portal_dir/src/assets/images/logo.svg" ;;
-    footer) dest="$portal_dir/src/assets/images/logo-notext.png" ;;
+    header)   dest="$portal_dir/src/assets/images/logo.$extension" ;;
+    footer) dest="$portal_dir/src/assets/images/logo-notext.$extension" ;;
     -h|--help) usage ;;
     *) echo "Error: unknown target '$choice'" >&2; usage ;;
 esac
@@ -40,14 +41,20 @@ if [[ ! -f "$src" ]]; then
     exit 1
 fi
 
-if [[ ! -f "$dest" ]]; then
-    echo "Error: destination '$dest' does not exist (portal layout may have changed)" >&2
-    exit 1
-fi
+# if [[ ! -f "$dest" ]]; then
+#     echo "Error: destination '$dest' does not exist (portal layout may have changed)" >&2
+#     exit 1
+# fi
 
 # Copy and echo
 cp -- "$src" "$dest"
 echo "Replaced $dest with $src"
+
+# Make sure the file type of the input is used in the output
+case "$choice" in
+    header) grep -rl 'images\/logo\.[A-Za-z]\+' $portal_dir | xargs sed -i -e 's/images\/logo\.[a-zA-Z]\+/images\/logo.'$extension'/g' ;;
+    footer) grep -rl 'images\/logo-notext\.[A-Za-z]\+' $portal_dir | xargs sed -i -e 's/images\/logo-notext\.[a-zA-Z]\+/images\/logo-notext.'$extension'/g' ;;
+esac
 
 # If data-portal is currently running, recompose it
 docker ps | grep "candig-data-portal"

--- a/replace_logo.sh
+++ b/replace_logo.sh
@@ -60,7 +60,6 @@ else
 fi
 
 # If data-portal is currently running, recompose it
-docker ps | grep "candig-data-portal"
-if [ $? -eq 0 ]; then
-    make recompose-candig-data-portal
+if docker ps | grep "candig-data-portal"; then
+    (cd "$script_dir" && make recompose-candig-data-portal)
 fi

--- a/replace_logo.sh
+++ b/replace_logo.sh
@@ -46,10 +46,18 @@ cp -- "$src" "$dest"
 echo "Replaced $dest with $src"
 
 # Make sure the file type of the input is used in the output
-case "$choice" in
-    header) grep -rl 'images\/logo\.[A-Za-z]\+' $portal_dir | xargs sed -i -e 's/images\/logo\.[a-zA-Z]\+/images\/logo.'$extension'/g' ;;
-    footer) grep -rl 'images\/logo-notext\.[A-Za-z]\+' $portal_dir | xargs sed -i -e 's/images\/logo-notext\.[a-zA-Z]\+/images\/logo-notext.'$extension'/g' ;;
-esac
+# Since sed works differently between the GNU and BSD versions, we'll execute different things depending
+if sed --version 2>/dev/null | grep -q GNU; then
+    case "$choice" in
+        header) grep -rl 'images\/logo\.[A-Za-z]\+' $portal_dir | xargs sed -i -e 's/images\/logo\.[a-zA-Z]\+/images\/logo.'$extension'/g' ;;
+        footer) grep -rl 'images\/logo-notext\.[A-Za-z]\+' $portal_dir | xargs sed -i -e 's/images\/logo-notext\.[a-zA-Z]\+/images\/logo-notext.'$extension'/g' ;;
+    esac
+else
+    case "$choice" in
+        header) grep -Erl 'images\/logo\.[A-Za-z]+' $portal_dir | xargs sed -i '' -E 's/images\/logo\.[a-zA-Z]+/images\/logo.'$extension'/g' ;;
+        footer) grep -Erl 'images\/logo-notext\.[A-Za-z]+' $portal_dir | xargs sed -i '' -E 's/images\/logo-notext\.[a-zA-Z]+/images\/logo-notext.'$extension'/g' ;;
+    esac
+fi
 
 # If data-portal is currently running, recompose it
 docker ps | grep "candig-data-portal"

--- a/replace_logo.sh
+++ b/replace_logo.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage hint
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") <header|footer> <source-file>
+
+Overwrites one of the Data Portal logo files with <source-file>.
+
+Targets:
+  header   src/assets/images/logo.svg        (header logo, 301x119 by default)
+  footer   src/assets/images/logo-notext.png (footer logo, 50x63 by default)
+EOF
+    exit 1
+}
+
+if [[ $# -ne 2 ]]; then
+    usage
+fi
+
+choice=$1
+src=$2
+
+# https://stackoverflow.com/a/246128/2148998 -- apparently this is the safest way to get the script directory
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+portal_dir="$script_dir/lib/candig-data-portal/candig-data-portal"
+
+# Figure out what to overwrite
+case "$choice" in
+    header)   dest="$portal_dir/src/assets/images/logo.svg" ;;
+    footer) dest="$portal_dir/src/assets/images/logo-notext.png" ;;
+    -h|--help) usage ;;
+    *) echo "Error: unknown target '$choice'" >&2; usage ;;
+esac
+
+# Error handling
+if [[ ! -f "$src" ]]; then
+    echo "Error: source file '$src' does not exist" >&2
+    exit 1
+fi
+
+if [[ ! -f "$dest" ]]; then
+    echo "Error: destination '$dest' does not exist (portal layout may have changed)" >&2
+    exit 1
+fi
+
+# Copy and echo
+cp -- "$src" "$dest"
+echo "Replaced $dest with $src"
+
+# If data-portal is currently running, recompose it
+docker ps | grep "candig-data-portal"
+if [ $? -eq 0 ]; then
+    make recompose-candig-data-portal
+fi


### PR DESCRIPTION
[Jira ticket](https://candig.atlassian.net/browse/DIG-1809)

This adds a script that replaces either of the logos on data portal (there's on in the header and one in the footer). This should help people more easily replace the logo as needed? It auto-restarts data-portal if it finds that the data portal is currently running.
Disclaimer: original verison of this script was "vibe coded", but it was uncommented, and didn't quite do what I wanted so I rewrote it into the following script

This was the .svg I used to test:
<img width="300" height="119" alt="logo" src="https://github.com/user-attachments/assets/91a25900-7b0e-42a0-8fe9-0254ba1b5a93" />

via:
```
./replace_logo.sh header ~/Downloads/logo.svg
```
