### PR TITLE
Fixup federation tests' urls

### DIFF
--- a/etc/tests/federation/test_federation.py
+++ b/etc/tests/federation/test_federation.py
@@ -358,7 +358,7 @@ def test_querying_site_query_authorized_remote_test_dataset():
     # Step 1: can we do a discovery query successfully to all sites?
     body = {
         "method": "GET",
-        "path": "discovery/programs",
+        "path": "query/discovery/programs",
         "payload": {},
         "service": "query"
     }
@@ -384,7 +384,7 @@ def test_querying_site_query_authorized_remote_test_dataset():
     programs -= {"TEST_FEDERATE"}
     body = {
         "method": "GET",
-        "path": "query",
+        "path": "query/query",
         "payload": {"exclude_programs": ",".join(programs)},
         "service": "query"
     }
@@ -417,7 +417,7 @@ def test_querying_site_query_unauthorized_remote_test_dataset():
     # Step 1: can we do a discovery query successfully to all sites?
     body = {
         "method": "GET",
-        "path": "discovery/programs",
+        "path": "query/discovery/programs",
         "payload": {},
         "service": "query"
     }
@@ -443,7 +443,7 @@ def test_querying_site_query_unauthorized_remote_test_dataset():
     programs -= {"TEST_FEDERATE"}
     body = {
         "method": "GET",
-        "path": "query",
+        "path": "query/query",
         "payload": {"exclude_programs": ",".join(programs)},
         "service": "query"
     }
@@ -493,7 +493,7 @@ def test_remove_servers():
         "service": "htsget",
         "method": "GET",
         "payload": {},
-        "path": "beacon/v2/service-info",
+        "path": "htsget/beacon/v2/service-info",
     }
     response = requests.post(
         f"{ENV['CANDIG_URL']}/federation/v1/fanout", headers=headers, json=body

--- a/etc/tests/federation/test_federation.py
+++ b/etc/tests/federation/test_federation.py
@@ -89,10 +89,10 @@ def test_all_service_info():
     }
     endpoints = {
         # all of these endpoints should return JSON
-        "htsget": f"ga4gh/drs/v1/service-info",
+        "htsget": f"{ENV['CANDIG_ENV']['TYK_HTSGET_API_LISTEN_PATH']}/beacon/v2/service-info",
         "katsu": f"v3/service-info",
         # "rnaget": f"service-info",
-        "query": f"service-info",
+        "query": f"query/service-info",
     }
     responses = []
     for module in modules:


### PR DESCRIPTION
#1343 changes how federation fanout calls' paths work, so this updates them in the federation tests.