### PR TITLE
DIG-2344: use as_self param when initializing our server

### DIFF
--- a/lib/federation/initialize.py
+++ b/lib/federation/initialize.py
@@ -55,7 +55,7 @@ def main():
     server = get_default_server()
     if json.dumps(server['server'], sort_keys=True) not in json.dumps(response.json(), sort_keys=True):
         print("Adding our server to the federation")
-        requests.request("POST", url, headers=headers, json=server)
+        requests.request("POST", url, headers=headers, json=server, params={"as_self": True})
         response = requests.request("GET", url, headers=headers)
     print(response.text)
 


### PR DESCRIPTION
Added an as_self boolean parameter to the federation POST /server endpoint, so that when we add our server to the federation (as we do on initialization), we mark it as our self. When returning servers with get_registered_servers(), return self as the first server.

To test: /service-info should return our own server. If you then POST to /server with a different server and use the as_self param, you should then get that other server from the service-info endpoint. If you then POST to /server with your own server as_self again, you should then get your own server back at the service-info endpoint.