### PR TITLE
Hotfix: htsget shouldn't re-try indexing failed files

### DIFF
--- a/lib/htsget/docker-compose.yml
+++ b/lib/htsget/docker-compose.yml
@@ -32,6 +32,7 @@ services:
       INDEXING_PATH: /home/candig/tmp/indexer
       INDEXING_SWITCH_FILE: /home/candig/indexer_on
       SEARCH_PATH: /home/candig/tmp/search
+      FAILURE_PATH: /home/candig/tmp/failed
       TESTENV_URL: ${HTSGET_PRIVATE_URL}
       POSTGRES_DATABASE: "genomic"
       POSTGRES_HOST_FILE: "postgres-db"


### PR DESCRIPTION
Small hotfix: if a file fails to index, move the stub file from /home/candig/tmp/indexer to /home/candig/tmp/failed, so that it won't try indexing it again on restart.

To test: open `lib/htsget/htsget_app/htsget_server/indexing.py` and add a fake exception at line 31:
```
    if gen_obj['type'] == 'read':
        raise Exception("test exception")
        return {"message": f"Read object {drs_obj_id} stats calculated"}, 200
```

Then run `make test-integration`. After it's done running, you should see just the read files in the FAILURE_PATH:
```
CanDIGv2$ docker exec candigv2_htsget_1 ls /home/candig/tmp/failed/
local-SYNTH_01~local-NA02102-bam
local-SYNTH_01~local-NA02102-cram
local-SYNTH_02~local-HG00100-chrom20-bam
local-SYNTH_02~local-HG00100-cram
```