### PR TITLE
DIG-2367: check for suspiciously small vault restore file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ mkdir:
 	mkdir -p bin
 	mkdir -p $(CONDA_INSTALL)
 	mkdir -p tmp/secrets
+	mkdir -p tmp/backups
 
 
 #>>>

--- a/Makefile
+++ b/Makefile
@@ -638,6 +638,10 @@ backup-vault:
 # if there is a restore file available, restore it and then run compose-opa again
 restore-vault:
 	ls lib/vault/restore.tar.gz
+	@bash lib/vault/check_restore.sh
+	@if [[ $$? -eq 1 ]]; then \
+		exit 0; \
+	fi
 	-$(MAKE) clean-vault
 	-$(MAKE) secret-vault-approle-token
 	-$(MAKE) docker-volumes

--- a/etc/env/example-production.env
+++ b/etc/env/example-production.env
@@ -21,6 +21,9 @@ CANDIG_USER_KEY=preferred_username
 # Set KEEP_TEST_DATA to true to have the integration tests keep all test data
 KEEP_TEST_DATA=false
 
+# Backup
+BACKUP_LOCATION=tmp/backups
+
 # Federation
 FEDERATION_PORT=4232
 FEDERATION_SERVICE_URL=http://${CANDIG_INTERNAL_DOMAIN}:${FEDERATION_PORT}

--- a/etc/env/example.env
+++ b/etc/env/example.env
@@ -22,6 +22,9 @@ CANDIG_USER_KEY=preferred_username
 # Set KEEP_TEST_DATA to true to have the integration tests keep all test data
 KEEP_TEST_DATA=false
 
+# Backup
+BACKUP_LOCATION=tmp/backups
+
 # Federation
 FEDERATION_PORT=4232
 FEDERATION_SERVICE_URL=http://${CANDIG_INTERNAL_DOMAIN}:${FEDERATION_PORT}

--- a/lib/vault/check_restore.sh
+++ b/lib/vault/check_restore.sh
@@ -1,0 +1,15 @@
+# check to see if we need to restore a backup before initializing a fresh Vault:
+if [[ -f "lib/vault/restore.tar.gz" ]]; then
+  size="$(wc -c <"lib/vault/restore.tar.gz")"
+
+  if [[ $(($size)) < 50000 ]]; then
+    echo -e "🚨🚨🚨 ${RED}BAD RESTORE FILE${DEFAULT} 🚨🚨🚨"
+    echo "The backup you are restoring from is less than 50kb in size, which is suspiciously small."
+    read -r -p 'Do you want to continue restoring? (y/n) ' choice
+    case "$choice" in
+      n|N) exit 1;;
+      y|Y) exit 0;;
+      *) echo 'Response not valid';;
+    esac
+  fi
+fi

--- a/lib/vault/make_backup.sh
+++ b/lib/vault/make_backup.sh
@@ -16,5 +16,6 @@ cd $(pwd)/tmp/vault
 tar -cz backup > backup.tar.gz
 rm -R backup
 cd $pwd
+mv $(pwd)/tmp/vault/backup.tar.gz $(pwd)/$BACKUP_LOCATION/vault.tar.gz
 
 start=$(docker start $vault)

--- a/lib/vault/vault_setup.sh
+++ b/lib/vault/vault_setup.sh
@@ -45,19 +45,19 @@ if [[ -f "lib/vault/restore.tar.gz" ]]; then
   if [[ $(($size)) < 50000 ]]; then
     echo -e "🚨🚨🚨 ${RED}BAD RESTORE FILE${DEFAULT} 🚨🚨🚨"
     echo "The backup you are restoring from is less than 50kb in size, which is suspiciously small."
-    docker stop $vault
-    pwd=$(pwd)
-    cd lib/vault/tmp
-    tar -xzf $pwd/lib/vault/restore.tar.gz
-    cd $pwd
-    cp lib/vault/tmp/backup/keys.txt tmp/vault/
-    cp lib/vault/tmp/backup/service_stores.txt tmp/vault/
-    docker cp lib/vault/tmp/backup/keys.txt $vault_runner:/vault/config/
-    docker cp lib/vault/tmp/backup/backup.tar.gz $vault_runner:/vault/
-    docker exec $vault_runner bash -c "cd /vault; tar -xzf backup.tar.gz"
-    rm -R lib/vault/tmp/backup
-    mv lib/vault/restore.tar.gz lib/vault/restored.tar.gz
   fi
+  docker stop $vault
+  pwd=$(pwd)
+  cd lib/vault/tmp
+  tar -xzf $pwd/lib/vault/restore.tar.gz
+  cd $pwd
+  cp lib/vault/tmp/backup/keys.txt tmp/vault/
+  cp lib/vault/tmp/backup/service_stores.txt tmp/vault/
+  docker cp lib/vault/tmp/backup/keys.txt $vault_runner:/vault/config/
+  docker cp lib/vault/tmp/backup/backup.tar.gz $vault_runner:/vault/
+  docker exec $vault_runner bash -c "cd /vault; tar -xzf backup.tar.gz"
+  rm -R lib/vault/tmp/backup
+  mv lib/vault/restore.tar.gz lib/vault/restored.tar.gz
 fi
 
 # if vault isn't started, start it:

--- a/lib/vault/vault_setup.sh
+++ b/lib/vault/vault_setup.sh
@@ -4,6 +4,13 @@ set -Euo pipefail
 
 LOGFILE=tmp/progress.txt
 
+# Terminal colors
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+GREEN='\033[0;32m'
+DEFAULT='\033[0m'
+
 # make sure we have all the env vars:
 source env.sh
 
@@ -32,18 +39,28 @@ docker cp lib/vault/tmp/vault-config.json $vault:/vault/config/
 # check to see if we need to restore a backup before initializing a fresh Vault:
 if [[ -f "lib/vault/restore.tar.gz" ]]; then
   echo ">> restoring vault from backup"
-  docker stop $vault
-  pwd=$(pwd)
-  cd lib/vault/tmp
-  tar -xzf $pwd/lib/vault/restore.tar.gz
-  cd $pwd
-  cp lib/vault/tmp/backup/keys.txt tmp/vault/
-  cp lib/vault/tmp/backup/service_stores.txt tmp/vault/
-  docker cp lib/vault/tmp/backup/keys.txt $vault_runner:/vault/config/
-  docker cp lib/vault/tmp/backup/backup.tar.gz $vault_runner:/vault/
-  docker exec $vault_runner bash -c "cd /vault; tar -xzf backup.tar.gz"
-  rm -R lib/vault/tmp/backup
-  mv lib/vault/restore.tar.gz lib/vault/restored.tar.gz
+
+  size="$(wc -c <"lib/vault/restore.tar.gz")"
+
+  if [[ $(($size)) < 50000 ]]; then
+    echo -e "🚨🚨🚨 ${RED}BAD RESTORE FILE${DEFAULT} 🚨🚨🚨"
+    echo "The backup you are restoring from is less than 50kb in size, which is suspiciously small."
+    echo "Creating new vault from scratch."
+    mv lib/vault/restore.tar.gz lib/vault/not_restored.tar.gz
+  else
+    docker stop $vault
+    pwd=$(pwd)
+    cd lib/vault/tmp
+    tar -xzf $pwd/lib/vault/restore.tar.gz
+    cd $pwd
+    cp lib/vault/tmp/backup/keys.txt tmp/vault/
+    cp lib/vault/tmp/backup/service_stores.txt tmp/vault/
+    docker cp lib/vault/tmp/backup/keys.txt $vault_runner:/vault/config/
+    docker cp lib/vault/tmp/backup/backup.tar.gz $vault_runner:/vault/
+    docker exec $vault_runner bash -c "cd /vault; tar -xzf backup.tar.gz"
+    rm -R lib/vault/tmp/backup
+    mv lib/vault/restore.tar.gz lib/vault/restored.tar.gz
+  fi
 fi
 
 # if vault isn't started, start it:

--- a/lib/vault/vault_setup.sh
+++ b/lib/vault/vault_setup.sh
@@ -46,6 +46,12 @@ if [[ -f "lib/vault/restore.tar.gz" ]]; then
     echo -e "🚨🚨🚨 ${RED}BAD RESTORE FILE${DEFAULT} 🚨🚨🚨"
     echo "The backup you are restoring from is less than 50kb in size, which is suspiciously small."
     echo "Creating new vault from scratch."
+    pwd=$(pwd)
+    cd lib/vault/tmp
+    tar -xzf $pwd/lib/vault/restore.tar.gz
+    cd $pwd
+    cp lib/vault/tmp/backup/service_stores.txt tmp/vault/
+    rm -R lib/vault/tmp/backup
     mv lib/vault/restore.tar.gz lib/vault/not_restored.tar.gz
   else
     docker stop $vault

--- a/lib/vault/vault_setup.sh
+++ b/lib/vault/vault_setup.sh
@@ -45,15 +45,6 @@ if [[ -f "lib/vault/restore.tar.gz" ]]; then
   if [[ $(($size)) < 50000 ]]; then
     echo -e "🚨🚨🚨 ${RED}BAD RESTORE FILE${DEFAULT} 🚨🚨🚨"
     echo "The backup you are restoring from is less than 50kb in size, which is suspiciously small."
-    echo "Creating new vault from scratch."
-    pwd=$(pwd)
-    cd lib/vault/tmp
-    tar -xzf $pwd/lib/vault/restore.tar.gz
-    cd $pwd
-    cp lib/vault/tmp/backup/service_stores.txt tmp/vault/
-    rm -R lib/vault/tmp/backup
-    mv lib/vault/restore.tar.gz lib/vault/not_restored.tar.gz
-  else
     docker stop $vault
     pwd=$(pwd)
     cd lib/vault/tmp

--- a/settings.py
+++ b/settings.py
@@ -55,6 +55,7 @@ def get_env():
     vars["KEYCLOAK_REALM"] = get_env_value("KEYCLOAK_REALM")
     vars["KEYCLOAK_LOGIN_REDIRECT_PATH"] = get_env_value("KEYCLOAK_LOGIN_REDIRECT_PATH")
     vars["DEFAULT_ADMIN_USER"] = get_env_value("DEFAULT_ADMIN_USER")
+    vars["BACKUP_LOCATION"] = get_env_value("BACKUP_LOCATION")
     vars["VAULT_URL"] = get_env_value("VAULT_SERVICE_PUBLIC_URL")
     vars["OPA_URL"] = get_env_value("OPA_URL")
     vars["TYK_LOGIN_TARGET_URL"] = get_env_value("TYK_LOGIN_TARGET_URL")


### PR DESCRIPTION
Do a clean install on your local system. Run `make backup-vault` on the fresh system to get a tiny backup file: `tmp/backups/vault.tar.gz` should be less than 50kb in size.

Copy that file to `lib/vault/restore.tar.gz` to trigger a restore-from-backup and then run `make restore-vault`. Watch the progress. When you get to "restoring vault from backup", you should get "BAD RESTORE FILE" etc. The file should be moved to `not_restored.tar.gz`.

Run integration tests to get a small amount of data into your vault and then run `make backup-vault` again. This file should now be bigger than 50kb.

Copy that file to `lib/vault/restore.tar.gz` to trigger a restore-from-backup and then run `make restore-vault`. This time, vault should be restored from backup and you should be able to use the site admin token to see data:
```
curl "http://candig.docker.internal:5080/ingest/program" \
     -H 'Authorization: Bearer <site admin token>'

[
  "PROGRAM-2",
  "PROGRAM-1",
  "TEST_2",
  "TEST_3",
  "local-SYNTH_01",
  "local-SYNTH_02",
  "local-SYNTH_03",
  "local-SYNTH_04"
]

```