### PR TITLE
DIG-2372: add compose-query to restore-vault

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -648,3 +648,4 @@ restore-vault:
 	-$(MAKE) build-vault
 	-$(MAKE) compose-vault
 	-$(MAKE) compose-opa
+	-$(MAKE) compose-query


### PR DESCRIPTION
Query needs to run its setup script again to make sure it's got the correct tokens for vault etc.

`make clean-all`, `make test-integration`, `make backup-vault`.
`make clean-all`, `make build-all`, use the restore from before and `make restore-vault`.
Tests should now pass.
