### PR TITLE
DIG-2378: make recipes for backing up and restoring postgres scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,7 @@ lib/minio/aws-credentials
 !/.git/
 !.gitignore
 !.gitmodules
+
+# Ignore restore/restored files
+lib/*/restore.*
+lib/*/restored.*

--- a/Makefile
+++ b/Makefile
@@ -676,8 +676,19 @@ backup-all-postgres:
 	@echo -e "🚨🚨🚨 Copy these backup files to an archival location! 🚨🚨🚨"
 
 
+restore_valid.%:
+	@if [ -e lib/$*/restore.txt ]; then \
+	restore=$(shell cat lib/$*/restore.txt); \
+	head $$restore | grep -q "PostgreSQL database dump"; \
+	if [[ $$? -eq 0 ]]; then touch restore_valid.$*; else \
+	echo "File $$restore does not exist or is not a valid sql file"; exit 1; fi; \
+	fi
+
+
+.INTERMEDIATE: restore_valid.%
+
 # for the given postgres-using module, if there is a restore file available, restore it
-restore-postgres-%:
+restore-postgres-%: restore_valid.% ;
 	@ls lib/$*/restore.txt && { make build-$*; make compose-$*; } || echo "To restore a database, a file at lib/$*/restore.txt needs to be created that contains the absolute path to the backup sql file."
 
 

--- a/Makefile
+++ b/Makefile
@@ -165,6 +165,7 @@ build-%:
 clean-%: warn
 	echo "    started clean-$*"
 	source setup_hosts.sh
+	python settings.py; source env.sh; \
 	export SERVICE_NAME=$*; \
 	docker compose -f lib/candigv2/docker-compose.yml -f lib/$*/docker-compose.yml down || true
 	-docker volume rm `docker volume ls --filter name=$* -q`
@@ -666,3 +667,20 @@ restore-vault:
 	-$(MAKE) compose-vault
 	-$(MAKE) compose-opa
 	-$(MAKE) compose-query
+
+
+# back up all postgres databases
+backup-all-postgres:
+	$(foreach DB, $(CANDIG_DB_NAMES), bash lib/postgres/backup_db.sh $(DB);)
+	@echo
+	@echo -e "🚨🚨🚨 Copy these backup files to an archival location! 🚨🚨🚨"
+
+
+# for the given postgres-using module, if there is a restore file available, restore it
+restore-postgres-%:
+	@ls lib/$*/restore.txt && { make build-$*; make compose-$*; } || echo "To restore a database, a file at lib/$*/restore.txt needs to be created that contains the absolute path to the backup sql file."
+
+
+# restore all of the postgres databases
+restore-all-postgres:
+	$(foreach MODULE, $(CANDIG_DB_MODULES), $(MAKE) restore-postgres-$(MODULE);)

--- a/Makefile
+++ b/Makefile
@@ -671,9 +671,13 @@ restore-vault:
 
 # back up all postgres databases
 backup-all-postgres:
+ifndef $(CANDIG_DB_NAMES)
+	@echo "Your .env file needs to be updated from example.env: it does not contain CANDIG_DB_NAMES"
+else
 	$(foreach DB, $(CANDIG_DB_NAMES), bash lib/postgres/backup_db.sh $(DB);)
 	@echo
 	@echo -e "🚨🚨🚨 Copy these backup files to an archival location! 🚨🚨🚨"
+endif
 
 
 restore_valid.%:
@@ -694,4 +698,8 @@ restore-postgres-%: restore_valid.% ;
 
 # restore all of the postgres databases
 restore-all-postgres:
+ifndef $(CANDIG_DB_MODULES)
+	@echo "Your .env file needs to be updated from example.env: it does not contain CANDIG_DB_MODULES"
+else
 	$(foreach MODULE, $(CANDIG_DB_MODULES), $(MAKE) restore-postgres-$(MODULE);)
+endif

--- a/Makefile
+++ b/Makefile
@@ -671,7 +671,7 @@ restore-vault:
 
 # back up all postgres databases
 backup-all-postgres:
-ifndef $(CANDIG_DB_NAMES)
+ifndef CANDIG_DB_NAMES
 	@echo "Your .env file needs to be updated from example.env: it does not contain CANDIG_DB_NAMES"
 else
 	$(foreach DB, $(CANDIG_DB_NAMES), bash lib/postgres/backup_db.sh $(DB);)
@@ -698,7 +698,7 @@ restore-postgres-%: restore_valid.% ;
 
 # restore all of the postgres databases
 restore-all-postgres:
-ifndef $(CANDIG_DB_MODULES)
+ifndef CANDIG_DB_MODULES
 	@echo "Your .env file needs to be updated from example.env: it does not contain CANDIG_DB_MODULES"
 else
 	$(foreach MODULE, $(CANDIG_DB_MODULES), $(MAKE) restore-postgres-$(MODULE);)

--- a/etc/env/example.env
+++ b/etc/env/example.env
@@ -62,6 +62,9 @@ CANDIG_MODULES=logging keycloak vault redis postgres drs htsget katsu rnaget que
 CANDIG_AUTH_MODULES=keycloak vault tyk opa federation
 CANDIG_DATA_MODULES=keycloak vault redis postgres logging
 
+CANDIG_DB_MODULES=drs htsget katsu rnaget
+CANDIG_DB_NAMES=${DRS_DB} ${HTSGET_DB} ${KATSU_DB} ${RNAGET_DB}
+
 # default name for built-in site admin
 DEFAULT_SITE_ADMIN_USER=site_admin@${CANDIG_SITE_LOCATION}-test.ca
 # Note: change to the preferred_username of your client for client auth grant
@@ -119,12 +122,14 @@ MINIO_SELF_CERT=0
 HTSGET_PRIVATE_URL=http://htsget:3000/${TYK_HTSGET_API_LISTEN_PATH}
 HTSGET_PUBLIC_URL=${TYK_LOGIN_TARGET_URL}/${TYK_HTSGET_API_LISTEN_PATH}
 HTSGET_PORT=3333
+HTSGET_DB=genomic
 
 
 # drs
 DRS_PRIVATE_URL=http://drs:3001/${TYK_DRS_API_LISTEN_PATH}
 DRS_PUBLIC_URL=${TYK_LOGIN_TARGET_URL}/${TYK_DRS_API_LISTEN_PATH}
 DRS_PORT=3001
+DRS_DB=drs
 
 
 # federation
@@ -145,6 +150,7 @@ KATSU_ALLOWED_HOSTS=${CANDIG_INTERNAL_DOMAIN},${CANDIG_DOMAIN},katsu,query
 KATSU_CACHE_DURATION=86400
 KATSU_WORKERS=2
 KATSU_THREADS=4
+KATSU_DB=clinical
 
 
 # keycloak service
@@ -173,6 +179,7 @@ ECS_IP_ADDR=127.0.0.1
 RNAGET_PORT=5005
 RNAGET_PRIVATE_URL=http://rnaget:5000
 RNAGET_INTERNAL_URL=http://${CANDIG_INTERNAL_DOMAIN}:${RNAGET_PORT}
+RNAGET_DB=rnaget_db
 
 # tyk service
 TYK_SERVICE_PUBLIC_PORT=5080

--- a/lib/drs/docker-compose.yml
+++ b/lib/drs/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       context: $PWD/lib/drs/drs
       args:
         venv_python: "${VENV_PYTHON}"
-    image: ${DOCKER_REGISTRY}/drs:${HTSGET_VERSION:-latest}
+    image: ${DOCKER_REGISTRY}/drs:${DRS_VERSION:-latest}
     labels:
       - "candigv2=drs"
     volumes:
@@ -27,11 +27,10 @@ services:
       OPA_URL: ${OPA_PRIVATE_URL}
       VAULT_URL: ${VAULT_PRIVATE_URL}
       DEBUG_MODE: ${CANDIG_DEBUG_MODE}
-      DB_PATH: "postgres-db"
+      DB_PATH: ${DB_PATH}
       SERVER_LOCAL_DATA: /app/drs_server/data
-      TESTENV_URL: ${HTSGET_PRIVATE_URL}
-      POSTGRES_DATABASE: "genomic"
-      POSTGRES_HOST_FILE: "postgres-db"
+      POSTGRES_DATABASE: ${DRS_DB}
+      POSTGRES_HOST_FILE: ${DB_PATH}
       POSTGRES_USERNAME: ${DEFAULT_ADMIN_USER}
       POSTGRES_PASSWORD_FILE: "/run/secrets/postgres-db-secret"
       SERVICE_NAME: ${SERVICE_NAME}

--- a/lib/drs/drs_preflight.sh
+++ b/lib/drs/drs_preflight.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -Euo pipefail
+
+LOGFILE=$PWD/tmp/progress.txt
+
+# This script runs before the container is composed.
+
+bash lib/postgres/restore_db.sh drs drs

--- a/lib/drs/drs_preflight.sh
+++ b/lib/drs/drs_preflight.sh
@@ -6,4 +6,4 @@ LOGFILE=$PWD/tmp/progress.txt
 
 # This script runs before the container is composed.
 
-bash lib/postgres/restore_db.sh drs drs
+bash lib/postgres/restore_db.sh $DRS_DB drs

--- a/lib/htsget/docker-compose.yml
+++ b/lib/htsget/docker-compose.yml
@@ -27,15 +27,15 @@ services:
       VAULT_URL: ${VAULT_PRIVATE_URL}
       DRS_URL: ${DRS_PRIVATE_URL}
       DEBUG_MODE: ${CANDIG_DEBUG_MODE}
-      DB_PATH: "postgres-db"
+      DB_PATH: ${DB_PATH}
       SERVER_LOCAL_DATA: /app/htsget_server/data
       INDEXING_PATH: /home/candig/tmp/indexer
       INDEXING_SWITCH_FILE: /home/candig/indexer_on
       SEARCH_PATH: /home/candig/tmp/search
       FAILURE_PATH: /home/candig/tmp/failed
       TESTENV_URL: ${HTSGET_PRIVATE_URL}
-      POSTGRES_DATABASE: "genomic"
-      POSTGRES_HOST_FILE: "postgres-db"
+      POSTGRES_DATABASE: ${HTSGET_DB}
+      POSTGRES_HOST_FILE: ${DB_PATH}
       POSTGRES_USERNAME: ${DEFAULT_ADMIN_USER}
       POSTGRES_PASSWORD_FILE: "/run/secrets/postgres-db-secret"
       AGGREGATE_COUNT_THRESHOLD: ${AGGREGATE_COUNT_THRESHOLD}

--- a/lib/htsget/htsget_preflight.sh
+++ b/lib/htsget/htsget_preflight.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -Euo pipefail
+
+LOGFILE=$PWD/tmp/progress.txt
+
+# This script runs before the container is composed.
+
+bash lib/postgres/restore_db.sh genomic htsget

--- a/lib/htsget/htsget_preflight.sh
+++ b/lib/htsget/htsget_preflight.sh
@@ -6,4 +6,4 @@ LOGFILE=$PWD/tmp/progress.txt
 
 # This script runs before the container is composed.
 
-bash lib/postgres/restore_db.sh genomic htsget
+bash lib/postgres/restore_db.sh $HTSGET_DB htsget

--- a/lib/katsu/docker-compose.yml
+++ b/lib/katsu/docker-compose.yml
@@ -15,8 +15,8 @@ services:
     extra_hosts:
       - "${CANDIG_DOMAIN}:${LOCAL_IP_ADDR}"
     environment:
-      - POSTGRES_DATABASE=clinical
-      - POSTGRES_HOST=postgres-db
+      - POSTGRES_DATABASE=${KATSU_DB}
+      - POSTGRES_HOST=${DB_PATH}
       - POSTGRES_PORT=5432
       - POSTGRES_USER=${DEFAULT_ADMIN_USER}
       - POSTGRES_PASSWORD_FILE=/run/secrets/postgres_db_secret

--- a/lib/katsu/katsu_preflight.sh
+++ b/lib/katsu/katsu_preflight.sh
@@ -6,4 +6,4 @@ LOGFILE=$PWD/tmp/progress.txt
 
 # This script runs before the container is composed.
 
-bash lib/postgres/restore_db.sh clinical katsu
+bash lib/postgres/restore_db.sh $KATSU_DB katsu

--- a/lib/katsu/katsu_preflight.sh
+++ b/lib/katsu/katsu_preflight.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -Euo pipefail
+
+LOGFILE=$PWD/tmp/progress.txt
+
+# This script runs before the container is composed.
+
+bash lib/postgres/restore_db.sh clinical katsu

--- a/lib/postgres/backup_db.sh
+++ b/lib/postgres/backup_db.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+python settings.py
+source env.sh
+
+db_name=$1
+
+postgres=$(docker ps -a --format "{{.Names}}" | grep postgres-db | awk '{print $1}')
+PGDATA=$(docker exec $postgres sh -c 'echo $PGDATA')
+
+echo "Making backup of ${db_name} database..."
+docker exec $postgres sh -c "pg_dump -U admin -d ${db_name} -f ${PGDATA}/${db_name}-backup.sql"
+if [[ $? -eq 0 ]]; then
+    docker cp $postgres:$PGDATA/${db_name}-backup.sql $(pwd)/$BACKUP_LOCATION/${db_name}-backup.sql
+fi
+docker exec $postgres sh -c "rm ${PGDATA}/${db_name}-backup.sql"
+
+echo
+echo "Saved $db_name backup to $BACKUP_LOCATION"
+ls -l $(pwd)/$BACKUP_LOCATION/${db_name}-backup.sql

--- a/lib/postgres/docker-compose.yml
+++ b/lib/postgres/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - POSTGRES_DB=clinical
       - POSTGRES_PASSWORD_FILE=/run/secrets/postgres_db_secret
       - POSTGRES_HOST_AUTH_METHOD=password
+      - PGDATA=/var/lib/postgresql/data
       - DEBUG_MODE=${CANDIG_DEBUG_MODE}
     extra_hosts:
       - "${CANDIG_DOMAIN}:${LOCAL_IP_ADDR}"

--- a/lib/postgres/restore_db.sh
+++ b/lib/postgres/restore_db.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -Euo pipefail
+
+LOGFILE=$PWD/tmp/progress.txt
+
+db_name=$1
+module=$2
+
+postgres=$(docker ps --format "{{.Names}}" | grep postgres-db | awk '{print $1}')
+container=$(docker ps --format "{{.Names}}" | grep ${module}_1 | awk '{print $1}')
+
+# look for database backup to restore
+restore=$(cat lib/$module/restore.txt)
+if [[ $? -eq 0 ]]; then
+    ls $restore
+    if [[ $? -eq 0 ]]; then
+        echo "restoring from backup file" $restore
+        docker stop $container
+        docker cp $restore $postgres:/var/lib/postgresql/data/${module}_restore.sql
+        docker exec $postgres sh -c "dropdb -U admin $db_name"
+        docker exec $postgres sh -c "createdb -U admin $db_name"
+        docker exec $postgres sh -c "psql -U admin -d $db_name < /var/lib/postgresql/data/${module}_restore.sql"
+        docker exec $postgres sh -c "rm /var/lib/postgresql/data/${module}_restore.sql"
+        mv lib/$module/restore.txt lib/$module/restored.txt
+        docker start $container
+    fi
+fi

--- a/lib/postgres/restore_db.sh
+++ b/lib/postgres/restore_db.sh
@@ -13,7 +13,7 @@ container=$(docker ps --format "{{.Names}}" | grep ${module}_1 | awk '{print $1}
 # look for database backup to restore
 restore=$(cat lib/$module/restore.txt)
 if [[ $? -eq 0 ]]; then
-    ls $restore
+    head $restore | grep -q "PostgreSQL database dump"
     if [[ $? -eq 0 ]]; then
         echo "restoring from backup file" $restore
         docker stop $container
@@ -24,5 +24,8 @@ if [[ $? -eq 0 ]]; then
         docker exec $postgres sh -c "rm /var/lib/postgresql/data/${module}_restore.sql"
         mv lib/$module/restore.txt lib/$module/restored.txt
         docker start $container
+    else
+        echo -e "🚨🚨🚨 Error! Restore file does not point to a valid sql dump file 🚨🚨🚨"
+        exit 1
     fi
 fi

--- a/lib/rnaget/docker-compose.yml
+++ b/lib/rnaget/docker-compose.yml
@@ -14,10 +14,10 @@ services:
       - CORS_ORIGINS="*"
       - BENTO_AUTHZ_SERVICE_URL=""
       - OPA_URL=${OPA_PRIVATE_URL}
-      - DB_HOST=postgres-db
+      - DB_HOST=${DB_PATH}
       - DB_PORT=5432
       - DB_USER=${DEFAULT_ADMIN_USER}
-      - DB_NAME=rnaget_db
+      - DB_NAME=${RNAGET_DB}
       - DB_PASSWORD_FILE=/run/secrets/db_password
       - WORKERS=2
     extra_hosts:

--- a/lib/rnaget/rnaget_preflight.sh
+++ b/lib/rnaget/rnaget_preflight.sh
@@ -12,3 +12,5 @@ cp -r $PWD/lib/rnaget/opa_plugin/* $PWD/lib/rnaget/rnaget/lib/
 cp -r $PWD/lib/rnaget/create_db.sh $PWD/lib/rnaget/rnaget/
 cp -r $PWD/lib/rnaget/run.bash $PWD/lib/rnaget/rnaget/
 cp -r $PWD/lib/rnaget/Dockerfile $PWD/lib/rnaget/rnaget/
+
+bash lib/postgres/restore_db.sh rnaget_db rnaget

--- a/lib/rnaget/rnaget_preflight.sh
+++ b/lib/rnaget/rnaget_preflight.sh
@@ -13,4 +13,4 @@ cp -r $PWD/lib/rnaget/create_db.sh $PWD/lib/rnaget/rnaget/
 cp -r $PWD/lib/rnaget/run.bash $PWD/lib/rnaget/rnaget/
 cp -r $PWD/lib/rnaget/Dockerfile $PWD/lib/rnaget/rnaget/
 
-bash lib/postgres/restore_db.sh rnaget_db rnaget
+bash lib/postgres/restore_db.sh $RNAGET_DB rnaget

--- a/settings.py
+++ b/settings.py
@@ -45,6 +45,7 @@ def get_env_value(key):
 
 def get_env():
     vars = {}
+    vars["CANDIG_ENV"] = INTERPOLATED_ENV
     vars["LOGFILE"] = get_env_value("LOGFILE")
     vars["CANDIG_URL"] = get_env_value("TYK_LOGIN_TARGET_URL")
     vars["CANDIG_CLIENT_ID"] = get_env_value("KEYCLOAK_CLIENT_ID")
@@ -63,6 +64,20 @@ def get_env():
     vars["CANDIG_DEBUG_MODE"] = get_env_value("CANDIG_DEBUG_MODE")
     vars["CANDIG_USER_KEY"] = get_env_value("CANDIG_USER_KEY")
     vars["VAULT_SERVICE_PUBLIC_URL"] = get_env_value("VAULT_SERVICE_PUBLIC_URL")
+    vars["POSTGRES_PASSWORD_FILE"] = os.path.abspath(f"tmp/postgres/db-secret")
+    vars["FEDERATION_SELF_SERVER_ID"] = get_env_value("FEDERATION_SELF_SERVER_ID")
+    vars["CANDIG_SITE_LOCATION"] = get_env_value("CANDIG_SITE_LOCATION")
+    vars["OIDC_CHAIN"] = get_env_value("OIDC_CHAIN").lower()
+    vars["KEYCLOAK_SERVICE_CLIENT_ID"] = get_env_value("KEYCLOAK_SERVICE_CLIENT_ID").lower()
+    vars["AUTH_ACCEPT_URL"] = get_env_value("AUTH_ACCEPT_URL")
+
+    # postgres envs
+    vars["DB_PATH"] = "postgres-db"
+    vars["DRS_DB"] = get_env_value("DRS_DB")
+    vars["HTSGET_DB"] = get_env_value("HTSGET_DB")
+    vars["KATSU_DB"] = get_env_value("KATSU_DB")
+    vars["RNAGET_DB"] = get_env_value("RNAGET_DB")
+
     # vars that come from files:
     if os.path.isfile("tmp/keycloak/client-secret"):
         with open("tmp/keycloak/client-secret") as f:
@@ -76,14 +91,6 @@ def get_env():
     if os.path.isfile("tmp/tyk/secret-key"):
         with open("tmp/tyk/secret-key") as f:
             vars["TYK_SECRET_KEY"] = f.read().splitlines().pop()
-    vars["POSTGRES_PASSWORD_FILE"] = os.path.abspath(f"tmp/postgres/db-secret")
-    vars["CANDIG_ENV"] = INTERPOLATED_ENV
-    vars["DB_PATH"] = "postgres-db"
-    vars["FEDERATION_SELF_SERVER_ID"] = get_env_value("FEDERATION_SELF_SERVER_ID")
-    vars["CANDIG_SITE_LOCATION"] = get_env_value("CANDIG_SITE_LOCATION")
-    vars["OIDC_CHAIN"] = get_env_value("OIDC_CHAIN").lower()
-    vars["KEYCLOAK_SERVICE_CLIENT_ID"] = get_env_value("KEYCLOAK_SERVICE_CLIENT_ID").lower()
-    vars["AUTH_ACCEPT_URL"] = get_env_value("AUTH_ACCEPT_URL")
 
     # test users (note that they must be all lowercase or keycloak setup fails):
     if get_env_value("DEFAULT_SITE_ADMIN_USER") is not None:


### PR DESCRIPTION
* Created new scripts in lib/postgres to backup and restore postgres databases:
   * backup_db.sh takes the name of the database as an argument and creates a backup file in the $BACKUP_LOCATION directory
   * restore_db.sh takes the name of the database and the name of the module as arguments, looks for a file named restore.txt in the lib/module directory, and restores from the sql file path listed in that file. (this is a path instead of a file because these sql files can be HUGE).
* Created some new variables in example.env: added vars for `DRS_DB`, `HTSGET_DB`, `KATSU_DB`, and `RNAGET_DB`. `CANDIG_DB_NAMES` lists those db names, while `CANDIG_DB_MODULES` specifies which modules use postgres dbs.
   * updated settings.py to save these names in env.sh
   * replaced direct references in docker-compose files etc to these variables
* When a preflight script gets run as part of `build-%`, restore_db.sh is run with the relevant arguments.
* Added Makefile targets for `backup-all-postgres`, `restore-postgres-%`, and `restore-all-postgres`, to make it easier for admins to run these correctly.

To test: run `make backup-all-postgres` on a local instance with test data. Note that the backup files are created in tmp/backups or wherever the $BACKUP_LOCATION is specified. Save these off somewhere else. 
Clean and build-all from scratch. Then create files in lib/$*/restore.txt, each containing the full path to the relevant backup file. When you run `make restore-all-postgres`, you should notice a bunch of psql commands being run. Integration tests should work again.