### PR TITLE
DIG-2400: check for recent backups

### DIFF
--- a/pre-build-check.sh
+++ b/pre-build-check.sh
@@ -84,7 +84,7 @@ fi
 if [[ $CANDIG_DEBUG_MODE == 0 ]]; then
     echo
     echo "Backup files located at ${BACKUP_LOCATION}:"
-    ls -lh $BACKUP_LOCATION
+    ls -lh $BACKUP_LOCATION | tail -n +2
     while [[ "$SILENT_MODE" != 1 ]]
     do
         read -r -p 'Do these backups look correct and up to date? (y/n) ' choice

--- a/pre-build-check.sh
+++ b/pre-build-check.sh
@@ -42,7 +42,7 @@ else
     echo "$DIFF_OUT"
     while [[ "$SILENT_MODE" != 1 ]]
     do
-        read -r -p 'Do you want to continue? (y/n)' choice
+        read -r -p 'Do you want to continue? (y/n) ' choice
         case "$choice" in
           n|N) exit 1;;
           y|Y) break;;
@@ -80,3 +80,18 @@ else
     fi
 fi
 
+# Check 7: (ONLY FOR PRODUCTION) Are there recent backups?
+if [[ $CANDIG_DEBUG_MODE == 0 ]]; then
+    echo
+    echo "Backup files located at ${BACKUP_LOCATION}:"
+    ls -l $BACKUP_LOCATION
+    while [[ "$SILENT_MODE" != 1 ]]
+    do
+        read -r -p 'Do these backups look correct and up to date? (y/n) ' choice
+        case "$choice" in
+          n|N) echo "You can create new backups with 'make backup-vault' and 'make backup-all-postgres'."; exit 1;;
+          y|Y) break;;
+          *) echo 'Response not valid';;
+        esac
+    done
+fi

--- a/pre-build-check.sh
+++ b/pre-build-check.sh
@@ -84,7 +84,7 @@ fi
 if [[ $CANDIG_DEBUG_MODE == 0 ]]; then
     echo
     echo "Backup files located at ${BACKUP_LOCATION}:"
-    ls -l $BACKUP_LOCATION
+    ls -lh $BACKUP_LOCATION
     while [[ "$SILENT_MODE" != 1 ]]
     do
         read -r -p 'Do these backups look correct and up to date? (y/n) ' choice


### PR DESCRIPTION
When running make build-all (or any other target that calls the pre-build-check script), make sure that the user sees the size and dates of the latest backups and confirms that they are good.

Set CANDIG_DEBUG_MODE=0 in your .env file and then run `make build-all`.

If you have never backed anything up, you will get
```
Backup files located at tmp/backups:
total 0
Do these backups look correct and up to date? (y/n)
```

Go ahead and finish building and running tests; then create some backups with `make backup-vault` and `make backup-all-postgres`. When you try to run `make build-all` again, you should see the contents of that backup location before being prompted as before.