### PR TITLE
Bump pip version and remove irrelevant line from makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,6 @@ build-all: mkdir
 
 # Setup the entire stack
 	$(MAKE) init-docker
-	pip install --upgrade setuptools
 	pip install -U -r etc/venv/requirements.txt
 	touch tmp/containers.txt
 	$(foreach MODULE, $(CANDIG_MODULES), $(MAKE) build-$(MODULE); $(MAKE) compose-$(MODULE);)

--- a/etc/env/versions.env
+++ b/etc/env/versions.env
@@ -1,7 +1,7 @@
 # Global versions
 CANDIG_VERSION=v7.0.0
 VENV_PYTHON=3.14
-VENV_PIP=24.0
+VENV_PIP=26.1.2
 ALPINE_VERSION=3.18
 
 # CanDIG submodules


### PR DESCRIPTION
Pip version was not compatible with python 3.14
Line in makefile shouldn't be needed anymore since we upgraded python and pip