### PR TITLE
Disable conda build and activate within nightly build

### DIFF
--- a/nightly_build.sh
+++ b/nightly_build.sh
@@ -57,10 +57,10 @@ fi
 # Re-source in case anything changed in the .env / nightly_env.sh files
 source nightly_env.sh
 
-make bin-conda
-source bin/miniforge/etc/profile.d/conda.sh
-make init-conda
-conda activate candig
+# make bin-conda
+# source bin/miniforge/etc/profile.d/conda.sh
+# make init-conda
+# conda activate candig
 make build-all BUILD_OPTS="--no-cache" ARGS="-s" >tmp/lastbuild.txt 2>&1
 if [ $? -ne 0 ]; then
     fail "Build failed:\n\`\`\`$(tail tmp/lastbuild.txt)\`\`\`"


### PR DESCRIPTION
I updated the cronjob on dev from
```
  24 0 4 * * * cd /opt/candig/CanDIGv2; ./nightly_build.sh
```
to 
```
  24 0 4 * * * cd /opt/candig/CanDIGv2; conda activate candig; ./nightly_build.sh
```
so we don't need to re-install conda and activate inside the script.

