### PR TITLE
Fix deep-link query params dropped through frontend auth redirect

### DIFF
--- a/lib/tyk/configuration_templates/frontendAuthMiddleware.js
+++ b/lib/tyk/configuration_templates/frontendAuthMiddleware.js
@@ -68,7 +68,7 @@ function setCookie(token, spec) {
 function setupRedirect(request, spec) {
     request.ReturnOverrides.ResponseCode = 302
     request.ReturnOverrides.ResponseHeaders = {
-        "Location": spec.config_data.TYK_SERVER + "/auth/login?app_url=" + request.URL
+        "Location": spec.config_data.TYK_SERVER + "/auth/login?app_url=" + encodeURIComponent(request.URL)
     }
     return request;
 }

--- a/lib/tyk/configuration_templates/virtualLogin.js
+++ b/lib/tyk/configuration_templates/virtualLogin.js
@@ -93,7 +93,10 @@ function loginHandler(request, session, spec) {
         var location = loginHelper.getCookie(request, "tyk_app")
 
         if (location) {
-            location = location.split("=")[1];
+            // Everything after the first "=" is the stored app URL. Do NOT use
+            // split("=")[1]: the URL itself contains "=" (patientId=…&programId=…),
+            // so that would truncate it to "/patientView?patientId" and drop every param.
+            location = location.substring(location.indexOf("=") + 1);
         } else {
             location = ""
         }


### PR DESCRIPTION
## Problem
Opening a donor's patient view in a **new tab** (e.g. `/patientView?patientId=..&programId=..&location=..&submitterDonorId=..`) while the session needed re-login produced a **blank page with no console error**. The patient view loaded with `patientId` only — `programId`/`submitterDonorId` were gone — so `useClinicalPatientData` never fetched (it requires `programId && patientId`) and the genomic query early-returned. Intermittent: with a warm session the SPA loads directly with the full query string intact.

## Root cause — two truncations in the Tyk frontend-auth round-trip
1. **`frontendAuthMiddleware.js`** built the login redirect by concatenating the raw request URL:
   ```js
   "/auth/login?app_url=" + request.URL
   ```
   The URL's own `&` then terminated the `app_url` param, so everything after the first `&` was parsed as separate `/auth/login` params and discarded.
2. **`virtualLogin.js`** read the stored app URL from the `tyk_app` cookie with `location.split("=")[1]`. Because the URL itself contains `=` (`patientId=..&programId=..`), that kept only `"/patientView?patientId"`, dropping the value and every later param — exactly the observed URL.

## Fix
1. `encodeURIComponent(request.URL)` when building `app_url` → the full URL survives into the `tyk_app` cookie.
2. `location.substring(location.indexOf("=") + 1)` → take everything after the first `=` when reading the cookie back → the full URL survives into the post-login redirect.

Both are required: (1) preserves the `&` params into the cookie, (2) preserves them back out.

## Verification (against a live stack)
- Reproduced the original 302 with the raw, `&`-delimited `app_url`.
- After fix #1: the 302 `Location` now emits `app_url=%2FpatientView%3FpatientId%3D..%26programId%3D..` (percent-encoded).
- Simulated the full cookie round-trip: old parse → `/patientView?patientId`; new parse → full URL with all four params preserved.
- Both fixes deployed to a running Tyk (`tyk/reload` ok); pending in-browser confirmation of the new-tab patient-view flow.

## Note
`virtualLogout.js` stashes `app_url` in a cookie the same way; not changed here since the logout flow doesn't currently carry deep links, but it could be hardened similarly if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)